### PR TITLE
added recipes to move cuda at the core level

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-10.1-GCC-7.3.0.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-10.1-GCC-7.3.0.eb
@@ -1,4 +1,4 @@
-easyblock = "ModuleOnly"
+easyblock = 'Bundle'
 name = 'CUDA'
 version = '10.1'
 
@@ -11,5 +11,7 @@ description = """CUDA (formerly Compute Unified Device Architecture) is a parall
 toolchain = {'name': 'GCC', 'version': '7.3.0'}
 
 dependencies = [ ('CUDAcore','10.1.243') ]
+
+altroot = 'CUDAcore'
 
 moduleclass = 'system'

--- a/easybuild/easyconfigs/c/CUDA/CUDA-10.1.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-10.1.eb
@@ -1,0 +1,15 @@
+easyblock = "ModuleOnly"
+name = 'CUDA'
+version = '10.1'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = {'name': 'GCC', 'version': '7.3.0'}
+
+dependencies = [ ('CUDAcore','10.1.243') ]
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/c/CUDAcore/CUDAcore-10.1.243.eb
+++ b/easybuild/easyconfigs/c/CUDAcore/CUDAcore-10.1.243.eb
@@ -1,0 +1,19 @@
+easyblock = "EB_CUDA"
+name = 'CUDAcore'
+version = '10.1.243'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = ['https://developer.download.nvidia.com/compute/cuda/%(version_major_minor)s/Prod/local_installers/']
+sources = ['cuda_%(version)s_418.87.00_linux.run']
+checksums = ['e7c22dc21278eb1b82f34a60ad7640b41ad3943d929bebda3008b72536855d31']
+
+postinstallcmds = [ '/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s' ]
+hidden = True
+moduleclass = 'system'


### PR DESCRIPTION
These two recipes move CUDA at the core level through a new easyconfig, called CUDAcore, which is hidden. The new CUDA recipe use the ModuleOnly EasyBlock which is from https://github.com/easybuilders/easybuild-easyblocks/pull/1839