### PR TITLE
GCCcore: fix C_INCLUDE_PATH and CPLUS_INCLUDE_PATH

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.8.5-nix.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.8.5-nix.eb
@@ -12,6 +12,23 @@ toolchain = SYSTEM
 nix_profile = '/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-%(version)s'
 nix_attribute = 'gfortran48.cc'
 
+# this is necessary because of #include_next in some header files that need to include files in $NIXUSER_PROFILE/include
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+        'include/c++/%(version)s/backward',
+        'include/c++/%(version)s/x86_64-pc-linux-gnu',
+        'include/c++/%(version)s',
+    ],
+    'C_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+    ]
+}
+
 hidden = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0-nix.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0-nix.eb
@@ -12,6 +12,23 @@ toolchain = SYSTEM
 nix_profile = '/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-%(version)s'
 nix_attribute = 'gfortran.cc'
 
+# this is necessary because of #include_next in some header files that need to include files in $NIXUSER_PROFILE/include
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+        'include/c++/%(version)s/backward',
+        'include/c++/%(version)s/x86_64-pc-linux-gnu',
+        'include/c++/%(version)s',
+    ],
+    'C_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+    ]
+}
+
 hidden = True
 
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0-nix.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.4.0-nix.eb
@@ -13,7 +13,21 @@ nix_profile = '/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-%(version)s
 nix_attribute = 'gfortran6.cc'
 
 # this is necessary because of #include_next in some header files that need to include files in $NIXUSER_PROFILE/include
-modextrapaths = {'CPLUS_INCLUDE_PATH': 'include/c++/6.4.0'}
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+        'include/c++/%(version)s/backward',
+        'include/c++/%(version)s/x86_64-pc-linux-gnu',
+        'include/c++/%(version)s',
+    ],
+    'C_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+    ]
+}
 
 hidden = True
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-8.3.0-nix.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-8.3.0-nix.eb
@@ -13,7 +13,21 @@ nix_profile = '/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-%(version)s
 nix_attribute = 'gfortran8.cc'
 
 # this is necessary because of #include_next in some header files that need to include files in $NIXUSER_PROFILE/include
-modextrapaths = {'CPLUS_INCLUDE_PATH': 'include/c++/8.3.0'}
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+        'include/c++/%(version)s/backward',
+        'include/c++/%(version)s/x86_64-pc-linux-gnu',
+        'include/c++/%(version)s',
+    ],
+    'C_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+    ]
+}
 
 hidden = True
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-9.1.0-nix.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-9.1.0-nix.eb
@@ -13,7 +13,21 @@ nix_profile = '/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-%(version)s
 nix_attribute = 'gfortran9.cc'
 
 # this is necessary because of #include_next in some header files that need to include files in $NIXUSER_PROFILE/include
-modextrapaths = {'CPLUS_INCLUDE_PATH': 'include/c++/9.1.0'}
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+        'include/c++/%(version)s/backward',
+        'include/c++/%(version)s/x86_64-pc-linux-gnu',
+        'include/c++/%(version)s',
+    ],
+    'C_INCLUDE_PATH': [
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include-fixed',
+        'include',
+        'lib/gcc/x86_64-pc-linux-gnu/%(version)s/include',
+    ]
+}
 
 hidden = True
 


### PR DESCRIPTION
gcc and g++ look (via cpp) in various directories for header files. You
can get the list for C++ via:
cpp -x c++ -v /dev/null -o /dev/null
(see https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html)
The order of the search path is important since some headers such
as math.h include a statement such as #include_next <math.h> to
include the math.h file in a directory lower down the search path,
(see https://gcc.gnu.org/onlinedocs/cpp/Wrapper-Headers.html)

The order was incorrect for us which sometimes gave strange compilation
errors: e.g. for 5.4.0 we have:
```
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/include
 /cvmfs/soft.computecanada.ca/nix/store/m64vdgyzr1d29j8372iibl2m3ixg2f0d-gfortran-5.4.0/lib/gcc/x86_64-unknown-linux-gnu/5.4.0/../../../../include/c++/5.4.0
 /cvmfs/soft.computecanada.ca/nix/store/m64vdgyzr1d29j8372iibl2m3ixg2f0d-gfortran-5.4.0/lib/gcc/x86_64-unknown-linux-gnu/5.4.0/../../../../include/c++/5.4.0/x86_64-unknown-linux-gnu
 /cvmfs/soft.computecanada.ca/nix/store/m64vdgyzr1d29j8372iibl2m3ixg2f0d-gfortran-5.4.0/lib/gcc/x86_64-unknown-linux-gnu/5.4.0/../../../../include/c++/5.4.0/backward
 /cvmfs/soft.computecanada.ca/nix/store/m64vdgyzr1d29j8372iibl2m3ixg2f0d-gfortran-5.4.0/lib/gcc/x86_64-unknown-linux-gnu/5.4.0/include
 /cvmfs/soft.computecanada.ca/nix/store/m64vdgyzr1d29j8372iibl2m3ixg2f0d-gfortran-5.4.0/include
 /cvmfs/soft.computecanada.ca/nix/store/m64vdgyzr1d29j8372iibl2m3ixg2f0d-gfortran-5.4.0/lib/gcc/x86_64-unknown-linux-gnu/5.4.0/include-fixed
 /cvmfs/soft.computecanada.ca/nix/store/59wpzavgpf1syqd6zzgc385qkm0qrd35-glibc-2.24-dev/include
```

the trouble here is that math.h from
/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/include
really should be at the bottom, not at the top. This can be fixed
by setting CPLUS_INCLUDE_PATH and C_INCLUDE_PATH to move those
directories up, and also remove most of the store paths. With this patch we
now have (for 7.3.0 in this case)
```
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/include/c++/7.3.0
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/include/c++/7.3.0/x86_64-pc-linux-gnu
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/include/c++/7.3.0/backward
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/lib/gcc/x86_64-pc-linux-gnu/7.3.0/include
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/include
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/lib/gcc/x86_64-pc-linux-gnu/7.3.0/include-fixed
 /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/include
 /cvmfs/soft.computecanada.ca/nix/store/59wpzavgpf1syqd6zzgc385qkm0qrd35-glibc-2.24-dev/include
```
which matches the search order on non-Nix systems (the hashed glibc path
at the end here is superfluous and harmless, as all the headers in there
are included in
/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/include).