### PR TITLE
Qt5 5.12.8

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/PyQt5-5.12.3-fix-python2.patch
+++ b/easybuild/easyconfigs/q/Qt5/PyQt5-5.12.3-fix-python2.patch
@@ -1,0 +1,22 @@
+--- PyQt5_gpl-5.12.3/qpy/QtCore/qpycore_qstring.cpp	2019-06-25 12:41:02.000000000 -0000
++++ PyQt5_gpl-5.13.0/qpy/QtCore/qpycore_qstring.cpp	2019-07-04 16:44:12.000000000 -0000
+@@ -158,10 +158,17 @@
+ }
+ 
+ 
+-// Convert a Python Unicode object to a QString.
++// Convert a Python string object to a QString.
+ QString qpycore_PyObject_AsQString(PyObject *obj)
+ {
+-#if defined(PYQT_PEP_393)
++#if PY_MAJOR_VERSION <= 2
++    const char *obj_s = PyString_AsString(obj);
++
++    if (!obj_s)
++        return QString();
++
++    return QString::fromUtf8(obj_s);
++#elif defined(PYQT_PEP_393)
+     int char_size;
+     Py_ssize_t len;
+     void *data = sipUnicodeData(obj, &char_size, &len);

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.12.8-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.12.8-GCCcore-9.3.0.eb
@@ -4,51 +4,145 @@ name = 'Qt5'
 version = '5.12.8'
 modaltsoftname = 'qt'
 
-homepage = 'http://qt.io/'
+homepage = 'https://qt.io/'
 description = "Qt is a comprehensive cross-platform C++ application framework."
 
 toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = [
-    'http://download.qt.io/official_releases/qt/%(version_major_minor)s/%(version)s/single/',
-    'http://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/single/',
-    'https://www.riverbankcomputing.com/static/Downloads/sip/4.19.17/',
-    'https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.12.3/'
+    'https://download.qt.io/official_releases/qt/%(version_major_minor)s/%(version)s/single/',
+    'https://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/single/'
 ]
-sources = ['qt-everywhere-src-%(version)s.tar.xz', 'sip-4.19.17.tar.gz', 'PyQt5_gpl-5.12.3.tar.gz']
+sources = ['qt-everywhere-src-%(version)s.tar.xz']
 checksums = [
     '9142300dfbd641ebdea853546511a352e4bd547c4c7f25d61a40cd997af1f0cf',  # qt-everywhere-src-5.12.8.tar.xz
-    '12bcd8f4d5feefc105bc075d12c5090ee783f7380728563c91b8b95d0ec45df3',  # sip-4.19.17.tar.gz
-    '0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110',  # PyQt5_gpl-5.12.3.tar.gz
 ]
 
-builddependencies = [('pkg-config', '0.29.2')]
+builddependencies = [
+    ('binutils', '2.34'),
+    ('pkg-config', '0.29.2'),
+    # deps for QtWebEngine
+    ('Bison', '3.5.3'),
+    ('flex', '2.6.4'),
+    ('gperf', '3.1'),
+    #('Ninja', '1.10.0'),
+    #('Python', '3.8.2'),
+    ('re2c', '1.3'),
+    # upstream deps, rpath'ed libraries
+    ('double-conversion', '3.1.5'),
+    ('PCRE2', '10.34'),
+    ('libevent', '2.1.11'),
+    ('NSS', '3.51'),
+    ('snappy', '1.1.8'),
+    ('JasPer', '2.0.16'),
+]
+
+dependencies = [
+    ('GLib', '2.64.1'),
+    ('libpng', '1.6.37'),
+    # deps for QtWebEngine
+    ('X11', '20200222'),
+    ('DBus', '1.13.12'),
+    ('libGLU', '9.0.1'),
+    ('libjpeg-turbo', '2.0.4'),
+]
 
 # qtgamepad needs recent kernel/libevdev (fails on RHEL 6.x)
 configopts = '-skip qtgamepad'
+configopts += ' -no-feature-statx'      # bug 672856
+configopts += ' -no-feature-getentropy' # needs kernel 3.17
+configopts += ' -no-feature-renameat2'  # needs kernel 3.16
 
-dependencies = [
-    ('GLib', '2.53.5'),
-    ('libpng', '1.6.32'),
-    ('X11', '20171023'),
-    ('libGLU', '9.0.0'),
-]
+# make sure QtWebEngine component is being built & installed
+check_qtwebengine = True
 
-# *Note*: When building PyQt5 v5.11 or later you must configure SIP to create a private copy
-#         of the sip module using a command line similar to the following:
-# > python configure.py --sip-module PyQt5.sip
-# https://www.riverbankcomputing.com/static/Docs/PyQt5/installation.html#downloading-sip
-postinstallcmds = [
-	"module load python/3.6 && cd %(builddir)s/ && cp -r sip-4.19.17 sip-4.19.17-3.6 && cd sip-4.19.17-3.6 && python3.6 configure.py --sip-module PyQt5.sip --sysroot=%(installdir)s --sipdir=%(installdir)s/share/python3.6/sip INCDIR=$EBROOTPYTHON/include/python3.6m && make && make install",
-	"module load python/3.6 && cd %(builddir)s/ && cp -r PyQt5_gpl-5.12.3 PyQt5_gpl-5.12.3-3.6 && cd PyQt5_gpl-5.12.3-3.6 &&  export CPATH=$EBROOTPYTHON/include/python3.6m:$CPATH && export EBPYTHONPREFIXES=%(installdir)s && python3.6 configure.py --confirm --qmake=%(installdir)s/bin/qmake --sysroot=%(installdir)s --verbose --sip=%(installdir)s/bin/sip  --sip-incdir=%(installdir)s/include/python3.6m && make && make install",
-	"module load python/3.7 && cd %(builddir)s/ && cp -r sip-4.19.17 sip-4.19.17-3.7 && cd sip-4.19.17-3.7 && python3.7 configure.py --sip-module PyQt5.sip --sysroot=%(installdir)s --sipdir=%(installdir)s/share/python3.7/sip INCDIR=$EBROOTPYTHON/include/python3.7m && make && make install",
-	"module load python/3.7 && cd %(builddir)s/ && cp -r PyQt5_gpl-5.12.3 PyQt5_gpl-5.12.3-3.7 && cd PyQt5_gpl-5.12.3-3.7 &&  export CPATH=$EBROOTPYTHON/include/python3.7m:$CPATH && export EBPYTHONPREFIXES=%(installdir)s && python3.7 configure.py --confirm --qmake=%(installdir)s/bin/qmake --sysroot=%(installdir)s --verbose --sip=%(installdir)s/bin/sip  --sip-incdir=%(installdir)s/include/python3.7m && make && make install",
-	"module load python/3.8 && cd %(builddir)s/ && cp -r sip-4.19.17 sip-4.19.17-3.8 && cd sip-4.19.17-3.8 && python3.8 configure.py --sip-module PyQt5.sip --sysroot=%(installdir)s --sipdir=%(installdir)s/share/python3.8/sip INCDIR=$EBROOTPYTHON/include/python3.8 && make && make install",
-	"module load python/3.8 && cd %(builddir)s/ && cp -r PyQt5_gpl-5.12.3 PyQt5_gpl-5.12.3-3.8 && cd PyQt5_gpl-5.12.3-3.8 &&  export CPATH=$EBROOTPYTHON/include/python3.8:$CPATH && export EBPYTHONPREFIXES=%(installdir)s && python3.8 configure.py --confirm --qmake=%(installdir)s/bin/qmake --sysroot=%(installdir)s --verbose --sip=%(installdir)s/bin/sip  --sip-incdir=%(installdir)s/include/python3.8 && make && make install",
+multi_deps = {'Python': ['2.7', '3.6', '3.7', '3.8']}
+multi_deps_extensions_only = True
+
+exts_defaultclass = 'ConfigureMakePythonPackage'
+
+exts_default_options = {
+    'source_urls': ['https://www.riverbankcomputing.com/static/Downloads/%(name)s/%(version)s/'],
+}
+
+local_pylibdir = '%(installdir)s/lib/python${EBVERSIONPYTHON:0:3}/site-packages'
+local_pysharedir = '%(installdir)s/share/python%{EBVERSIONPYTHON:0:3}/site-packages'
+
+local_sip_configopts = " ".join([
+    "configure.py",
+    "--bindir %(installdir)s/bin",
+    "--incdir %(installdir)s/include",
+    "--destdir %s" % local_pylibdir,
+    "--sipdir=%s/sip" % local_pysharedir,
+    # required for PyQt5, cfr. https://www.riverbankcomputing.com/static/Docs/PyQt5/installation.html#downloading-sip
+    "--sip-module PyQt5.sip",
+    "--no-dist-info",
+    "--no-stubs",
+])
+
+local_pyqt5_configopts = " ".join([
+    "configure.py",
+    "--confirm-license --verbose --no-python-dbus",
+    "--bindir=%(installdir)s/bin",
+    "--destdir=%s" % local_pylibdir,
+    "--sip=%(installdir)s/bin/sip",
+    "--sip-incdir %s/sip" % local_pysharedir,
+    "--sipdir=%s/sip/PyQt5" % local_pysharedir,
+    "--designer-plugindir=%s/plugins/designer" % local_pysharedir,
+    "--qml-plugindir=%s/plugins/PyQt5" % local_pysharedir,
+    "--qsci-api-destdir=%s/qsci" % local_pysharedir,
+    "--no-dist-info",
+    "--no-stubs",
+])
+
+local_pyqtweb_configopts = " ".join([
+    "configure.py",
+    "--verbose",
+    "--destdir=%s/PyQt5" % local_pylibdir,
+    "--apidir=%s/qsci" % local_pysharedir,
+    "--pyqt-sipdir=%(builddir)s/PyQt5/PyQt5_gpl-5.12.3/sip",
+    "--no-dist-info",
+    "--no-stubs",
+])
+
+exts_list = [
+    ('enum34', '1.1.10', {
+        'modulename': 'enum',
+        'checksums': ['cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248'],
+        'source_urls': [PYPI_SOURCE],
+        'preconfigopts': '#',
+        'prebuildopts': '#',
+        'preinstallopts': '(cd .. && python -c "import enum") || pip install --prefix=%(installdir)s  --no-deps  --ignore-installed  --no-build-isolation . #'
+    }),
+    ('sip', '4.19.18', {
+        'modulename': 'PyQt5.sip',
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'checksums': ['c0bd863800ed9b15dcad477c4017cdb73fa805c25908b0240564add74d697e1e'],
+        'preconfigopts': 'mkdir -p %s/sip && '%local_pysharedir,
+        'configopts': local_sip_configopts,
+        'installopts': ' && make clean',
+    }),
+    ('PyQt5', '5.12.3', {
+        'modulename': 'PyQt5.QtCore',
+        'source_tmpl': '%(name)s_gpl-%(version)s.tar.gz',
+        'patches': ['PyQt5-5.12.3-fix-python2.patch'],
+        'checksums': ['0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110',
+                      '8cd9e0959476c25f6b70cad1c6f12e692b21a0528a1052048c6ae901f4b99ab8'],
+        'configopts': local_pyqt5_configopts,
+        'installopts': ' && make clean',
+    }),
+    ('PyQtWebEngine', '5.12.1', {
+        'modulename': 'PyQt5.QtWebEngine',
+        'source_tmpl': '%(name)s_gpl-%(version)s.tar.gz',
+        'checksums': ['860704672ea1b616e1347be1f347bc1c749e64ed378370863fe209e84e9bd473'],
+        'configopts': local_pyqtweb_configopts,
+        'installopts': ' && make clean',
+    }),
 ]
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
 modextrapaths = {
     'EBPYTHONPREFIXES': [''],
 }
-
 
 moduleclass = 'devel'


### PR DESCRIPTION
@mboisson this one builds, can you please review if I did not miss anything obvious?

I updated sip from 4.19.17 to .18 for Py 3.8 compatibility and made everything a bit more like the upstream recipes for PyQt and Qt.

For py2.7 we just need enum34 (which is not needed for py3), so the pip install is conditional there, it's a little hackish but it works.

In the end it seems the vectorizer can remain enabled I think (still waiting for the avx512 test build to finish..)

Also, we don't *have* to use PyQt 5.12 with Qt 5.12, a newer PyQt will do too (in case you didn't know, you may have other reasons..) as PyQt 5.x support Qt 5.y where y<=x.