### PR TITLE
use OS_PKG_OPENSSL_DEV constant in UCX 1.8.0 easyconfig on top of CUDA 11.0.2

### DIFF
--- a/easybuild/easyconfigs/u/UCX/UCX-1.8.0-GCCcore-9.3.0-CUDA-11.0.2.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.8.0-GCCcore-9.3.0-CUDA-11.0.2.eb
@@ -34,7 +34,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
 ]
 
-osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+osdependencies = [OS_PKG_OPENSSL_DEV]
 
 dependencies = [
     ('numactl', '2.0.13'),


### PR DESCRIPTION
@bartoldeman @mboisson for https://github.com/easybuilders/easybuild-easyconfigs/pull/11295