### PR TITLE
use modluafooter instead of patch file

### DIFF
--- a/easybuild/easyconfigs/x/XALT/XALT-2.10.15.eb
+++ b/easybuild/easyconfigs/x/XALT/XALT-2.10.15.eb
@@ -82,4 +82,10 @@ postinstallcmds = [
     "patchelf --remove-rpath %(installdir)s/lib64/{libxalt_init.so,libcrcFast.so}",
 ]
 
+# LD_PRELOAD is filtered out by the config. Bypass the filter with modluafooter.
+modluafooter = """
+prepend_path("LD_PRELOAD", pathJoin(root, "lib64/libxalt_init.so"))
+setenv("XALT_PRELOAD_ONLY", "no")
+"""
+
 moduleclass = 'lib'


### PR DESCRIPTION
A patch was needed for the previous version to add LD_PRELOAD and XALT_PRELOAD_ONLY to the resulting module file. By using modluafooter, we don't need the patch anymore.