### PR TITLE
add XALT_FILE_PREFIX to XALT modluafooter

### DIFF
--- a/easybuild/easyconfigs/x/XALT/XALT-2.10.15.eb
+++ b/easybuild/easyconfigs/x/XALT/XALT-2.10.15.eb
@@ -86,6 +86,7 @@ postinstallcmds = [
 modluafooter = """
 prepend_path("LD_PRELOAD", pathJoin(root, "lib64/libxalt_init.so"))
 setenv("XALT_PRELOAD_ONLY", "yes")
-"""
+setenv("XALT_FILE_PREFIX", "%s")
+""" % file_prefix
 
 moduleclass = 'lib'


### PR DESCRIPTION
Even if the variable is not set, the default value specified during the build is used, so I don't think we need to check if the directory exists before setting the variable.