### PR TITLE
install mii-1.1.0 for different architectures

### DIFF
--- a/easybuild/easyconfigs/m/mii/mii-1.1.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/m/mii/mii-1.1.0-GCCcore-9.3.0.eb
@@ -1,4 +1,6 @@
 #EasyBuild easyconfig
+import os
+
 easyblock = 'ConfigureMake'
 
 name = 'mii'
@@ -7,7 +9,7 @@ version = '1.1.0'
 homepage = 'https://github.com/codeandkey/mii'
 description = """A smart search engine for module environments."""
 
-toolchain = SYSTEM
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = ['https://github.com/codeandkey/mii/archive']
 sources = ['v%(version)s.tar.gz']
@@ -24,20 +26,26 @@ skipsteps = ['configure', 'build']
 installopts =  'PREFIX=%(installdir)s/ '
 installopts += 'MII_ENABLE_SPIDER=yes '
 
-postinstallcmds = ['mkdir -p %(installdir)s/data/']
+_arch = os.getenv("RSNT_ARCH")
+_index_dir = '/cvmfs/soft.computecanada.ca/custom/mii/data'
+_index_file = '%s/%s' % (_index_dir, _arch)
+_modulepath = '/cvmfs/soft.computecanada.ca/custom/modules'
+
+postinstallcmds = [
+    'mkdir -p %s' % _index_dir,
+    'MII_INDEX_FILE=%s %%(installdir)s/bin/mii build -m %s' % (_index_file, _modulepath)
+]
 
 sanity_check_paths = {
-    'files': ["bin/mii", "share/mii/init/bash", "share/mii/init/zsh", "share/mii/init/common"],
-    'dirs': [],
+    'files': ["bin/mii", "share/mii/init/bash", "share/mii/init/zsh", "share/mii/init/common", _index_file],
+    'dirs': [_index_dir],
 }
 
 sanity_check_commands = [('mii', 'version')]
 
 modluafooter = """
-local index_root = "/cvmfs/soft.computecanada.ca/custom/mii"
-
 setenv("MII", pathJoin(root, "bin/mii"))
-setenv("MII_INDEX_FILE", pathJoin(index_root, "data/index"))
+setenv("MII_INDEX_FILE", "%s")
 
 local shell = myShellName()
 
@@ -54,4 +62,4 @@ if (shell == "bash" or shell == "zsh") then
     -- Define command not found hook
     set_shell_function(hook_name, hook_def, "")
 end
-"""
+""" % _index_file


### PR DESCRIPTION
Enable the installation of mii for different architectures. When a new architecture is loaded, mii will also be reloaded and the index file used by mii will reflect the new architecture.

Also added the generation of architecture-specific indices from the recipe.

The recipe was tested with
```
parallel RSNT_ARCH={1} eb mii-1.1.0-GCCcore-9.3.0.eb ::: sse3 avx avx2 avx512
```