### PR TITLE
add cmd transposition to mii-1.1.0

### DIFF
--- a/easybuild/easyconfigs/m/mii/mii-1.1.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/m/mii/mii-1.1.0-GCCcore-9.3.0.eb
@@ -13,11 +13,12 @@ toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = ['https://github.com/codeandkey/mii/archive']
 sources = ['v%(version)s.tar.gz']
-patches = ['mii-1.1.0_global-index.patch', 'mii-1.1.0_hierarchic-modulepath.patch']
+patches = ['mii-1.1.0_global-index.patch', 'mii-1.1.0_hierarchic-modulepath.patch', 'mii-1.1.0_transposition.patch']
 checksums = [
     'cfca1318eac3db5f1452aaa82cb1a95de6175922075ba3fab1111b8594e6072c',  # v1.1.0.tar.gz
     '72db9fa725e542d56544f027e9462d10435ee8d7a2aad36880e78d3ee9ae23d3',  # mii-1.1.0_global-index.patch
-    '2814dba2b4600226c591e9f3f6e2e3c783b399c9ff2f95c59feb27371b3465e4',  # mii-1.1.0_hierarchic-modulepath.patch
+    'a59532b1778feeea0f3b92caf8a6fe700ecd05f306953de56a6f759928203a0c',  # mii-1.1.0_hierarchic-modulepath.patch
+    'f93e68a614c59d55fbf620279a1f31c8d9bd9dba8aa2f7e9982c983a5abce1bf',  # mii-1.1.0_transposition.patch
 ]
 
 # only make install is needed

--- a/easybuild/easyconfigs/m/mii/mii-1.1.0_transposition.patch
+++ b/easybuild/easyconfigs/m/mii/mii-1.1.0_transposition.patch
@@ -1,0 +1,36 @@
+From 01cfd765403ad7ae0f816fde66d5d68e196e1a50 Mon Sep 17 00:00:00 2001
+From: JLague <justin.lague@calculquebec.ca>
+Date: Mon, 9 Aug 2021 16:07:23 -0400
+Subject: [PATCH] check for transposition in levenshtein distance
+
+use the optimal string alignment distance to check
+for transposition of two adjacent characters
+---
+ src/util.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/util.c b/src/util.c
+index fa880ff..bd6cf14 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -34,7 +34,7 @@ char* mii_join_path(const char* a, const char* b) {
+ 
+ int mii_levenshtein_distance(const char* a, const char* b) {
+     /*
+-     * quickly compute the levenshtein distance between
++     * quickly compute the damerau-levenshtein distance between
+      * string <a> and <b> using a full matrix
+      */
+ 
+@@ -57,6 +57,11 @@ int mii_levenshtein_distance(const char* a, const char* b) {
+             int substitution = mat[(i - 1) * (b_len + 1) + j - 1] + (tolower(a[i - 1]) != tolower(b[j - 1]));
+ 
+             mat[i * (b_len + 1) + j] = mii_min(deletion, mii_min(insertion, substitution));
++
++            /* transposition with optimal string alignment distance */
++            if (i > 1 && j > 1 && tolower(a[i - 1]) == tolower(b[j - 2]) && tolower(a[i - 2]) == tolower(b[j - 1])) {
++                mat[i * (b_len + 1) + j] = mii_min(mat[i * (b_len + 1) + j], mat[(i - 2) * (b_len + 1) + j - 2] + 1);
++            }
+         }
+     }
+ 


### PR DESCRIPTION
Use the optimal string alignment distance to check for transposition of two adjacent characters. `ls` will then be higher in the search results when searching for `sl`.