### PR TITLE
add recipies for GROMACS-2020.4 and 2021.2 with FlexiBLAS and CUDA 11.4

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2020.4-gofbc-2020.1.403.114.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2020.4-gofbc-2020.1.403.114.eb
@@ -1,0 +1,48 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# License::   MIT/GPL
+# 2019.3 version
+# Contribution from the Crick HPC team
+# uploaded by J. Sassmannshausen
+#
+
+name = 'GROMACS'
+version = '2020.4'
+
+homepage = 'http://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI builds.
+
+- CC-Wiki: GROMACS
+"""
+
+toolchain = {'name': 'gofbc', 'version': '2020.1.403.114'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = []
+checksums = [
+    '5519690321b5500c7951aaf53ff624042c3edd1a5f5d6dd1f2d802a3ecdbf4e6',  # gromacs-2020.4.tar.gz
+]
+
+builddependencies = []
+
+dependencies = [('FFTW', '3.3.8')]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-gofbc-2020.1.403.114.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-gofbc-2020.1.403.114.eb
@@ -1,0 +1,54 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# License::   MIT/GPL
+# 2019.3 version
+# Contribution from the Crick HPC team
+# uploaded by J. Sassmannshausen
+#
+
+name = 'GROMACS'
+version = '2021.2'
+
+homepage = 'http://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI builds.
+
+- CC-Wiki: GROMACS
+"""
+
+toolchain = {'name': 'gofbc', 'version': '2020.1.403.114'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = []
+checksums = [
+    'd940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb',  # gromacs-2021.2.tar.gz
+]
+
+builddependencies = []
+
+dependencies = [('FFTW', '3.3.8')]
+
+# In GROMACS 2021.2 some tests are failing. According to the developers,
+# the "new listed forces calculation with NB-LIB" isn't used anywhere besides
+# these tests.
+# Testing is disabled, until I can figure out a less drastic workaround.
+skipsteps = ['test']
+
+moduleclass = 'chem'


### PR DESCRIPTION
Make both versions of GROMACS that we already had in StdEnv/2020 available with CUDA 11.4.

Both recipes produced functional binaries in my home directory.