### PR TITLE
Prevent compilation of MMseqs2 using the build node architecture

### DIFF
--- a/easybuild/easyconfigs/m/MMseqs2/MMseqs2-13-45111-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/m/MMseqs2/MMseqs2-13-45111-GCC-9.3.0.eb
@@ -16,7 +16,7 @@ builddependencies = [('CMake', '3.16.3')]
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=RELEASE'
+configopts = '-DCMAKE_BUILD_TYPE=RELEASE -DNATIVE_ARCH=0'
 
 modextrapaths = {'PATH': 'util'}
 

--- a/easybuild/easyconfigs/m/MMseqs2/MMseqs2-13-45111-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/m/MMseqs2/MMseqs2-13-45111-iccifort-2020.1.217.eb
@@ -16,7 +16,7 @@ builddependencies = [('CMake', '3.16.3')]
 
 separate_build_dir = True
 
-configopts = '-DCMAKE_BUILD_TYPE=RELEASE'
+configopts = '-DCMAKE_BUILD_TYPE=RELEASE -DNATIVE_ARCH=0'
 
 modextrapaths = {'PATH': 'util'}
 


### PR DESCRIPTION
Just adding -DNATIVE_ARCH=0. Solve Ticket 160488.