### PR TITLE
Add TRIQS 3.1.0 recipe. Yet can't install for python/3.10.

### DIFF
--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
@@ -34,18 +34,21 @@ builddependencies = [
     ('pytest', '7.0.1'),
 ]
 
-multi_deps = {'Python': ['3.8','3.9']}
+multi_deps = {'Python': ['3.8','3.9']} #note: triqs_maxent not compatible with Python 3.10
 
+#install Python package Mako needed for configure step
 preconfigopts = ' && '.join([
     'PYTHONPATH=$PYTHONPATH:%(builddir)s/lib/python%(pyshortver)s/site-packages',
     'pip install mako==1.1.4 --prefix=%(builddir)s/ && '
 ])
 
-#I had to reinstall mako after installing TRIQS
-#even when I installed it in the installdir or with
-#separate_build_dir = False
 installopts = ' && '.join([
+#reinstall mako needed for TRIQS extension 
+#don't use keeppreviousinstall=True as we need manually to delete the installdir during rebuild
     " && pip install --prefix=%(installdir)s mako==1.1.4 --no-index",
+#TRIQS set LD_LIBRARY_PATH for its Python extension to find its lib
+#However, we don't not use LD_LIBRARY_PATH and to avoid sourcing triqsvar.sh
+#each time, we add installdir/lib to the RPATH
     "/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s/lib --any_interpreter --add_path %(installdir)s/lib"
 ])
 

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
@@ -25,21 +25,82 @@ dependencies = [
     ('Clang', '13.0.1'),
     ('FFTW', '3.3.9'),
     ('HDF5', '1.12.1'),
-]
-
-builddependencies = [
-    ('CMake', '3.22.1'),
     ('mpi4py', '3.1.3'),
     ('SciPy-Stack', '2022a'),
 ]
 
-multi_deps = {'Python': ['3.8', '3.9', '3.10']}
+builddependencies = [
+    ('CMake', '3.22.1'),
+    ('pytest', '7.0.1'),
+]
 
-preconfigopts = 'pip install --prefix=%(builddir)s mako==1.1.4 && '
+multi_deps = {'Python': ['3.9']}
+
+preconfigopts = 'PYTHONPATH=$PYTHONPATH:%(builddir)s/lib/python%(pyshortver)s/site-packages; '
+preconfigopts += 'pip install mako==1.1.4 --prefix=%(builddir)s/ && '
+
+#I had to reinstall mako after installing TRIQS, even with separate_build_dir = False
+installopts = [
+    " && pip install --prefix=%(installdir)s mako==1.1.4 --no-index" +
+    " && /cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s/lib --any_interpreter --add_path %(installdir)s/lib"
+]
 
 separate_build_dir = True
 
 runtest = 'test'
+
+exts_defaultclass = "CMakePythonPackage"
+exts_list = [
+    ('triqs_maxent', '1.1.0', {
+        'source_urls' : ['https://github.com/TRIQS/maxent/releases/download/%(version)s/'],
+        'sources' : ['maxent-%(version)s.tar.gz'],
+        'checksums' : ['87523adabdfe0c6d0a1fd84bdc1b4bceed64361adde922809d85e19c155e4c68'],
+        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
+        'configopts': ' '.join([
+            '-DBuild_Documentation=OFF',
+            '-DMeasureG2=ON',
+            '-DHybridisation_is_complex=ON',
+            '-DLocal_hamiltonian_is_complex=ON',
+        ]),
+        'runtest': 'test',
+    }),
+    ('triqs_cthyb', '3.1.0', {
+        'source_urls' : ['https://github.com/TRIQS/cthyb/releases/download/%(version)s/'],
+        'sources' : ['cthyb-%(version)s.tar.gz'],
+        'checksums' : ['8d6d2c4d5b3928d062b72fad4ea9df9aae198e39dd9c1fd3cc5dc34a5019acc0'],
+        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
+        'runtest': 'test',
+    }),
+    ('triqs_hubbardI', '3.1.0', {
+        'source_urls' : ['https://github.com/TRIQS/hubbardI/releases/download/%(version)s/'],
+        'sources' : ['hubbardI-%(version)s.tar.gz'],
+        'checksums' : ['a5748c90bfe4138f37c516fad5fb4cdc02bca3283a2328558d9c3224e0d372c7'],
+        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
+        'runtest' : 'test',
+        'modulename' : 'triqs_hubbardI',
+    }),
+    ('triqs_tprf', '3.1.0', {
+        'source_urls' : ['https://github.com/TRIQS/tprf/releases/download/%(version)s/'],
+        'sources' : ['tprf-%(version)s.tar.gz'],
+        'checksums' : ['75f6e79d891342951652353ea4d9914074d9947c67cad60844ebaa3f82bd17b5'],
+        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
+        'runtest': 'test',
+    }),
+    ('triqs_dft_tools', '3.1.0', { #https://triqs.github.io/dft_tools/
+        'source_urls' : ['https://github.com/TRIQS/dft_tools/releases/download/%(version)s/'],
+        'sources' : ['dft_tools-%(version)s.tar.gz'],
+        'checksums' : ['57b7d0fe5a96c5a42bb684c60ca8e136a33e1385bf6cd7e9d1371fa507dc2ec4'],
+        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
+        'runtest': 'test',
+    }),
+    ('solid_dmft', '3.1.0', { #https://flatironinstitute.github.io/solid_dmft/      
+        'source_urls' : ['https://github.com/flatironinstitute/solid_dmft/archive/refs/tags/'],
+        'sources' : ['%(version)s.tar.gz'],
+        'checksums' : ['ac2f73cd350349d76c1344e7eb16b7cc7372b5ab284e8cc8a5d31de531a844c1'],
+        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
+        'runtest': 'test',
+    }),
+]
 
 sanity_check_paths = {
     'files': ['lib/libtriqs.%s' % SHLIB_EXT],
@@ -53,6 +114,8 @@ sanity_check_commands = [
     "python -c 'import triqs'"
 ]
 
-modextrapaths = {'EBPYTHONPREFIXES': ['']}
+modextrapaths = {
+    'EBPYTHONPREFIXES': [''],
+}
 
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
@@ -13,7 +13,7 @@ description = """
 docurls = ['https://triqs.github.io/triqs/%(version_major_minor)s.x/']
 software_license = 'LicenseGPLv3'
 
-toolchain = {'name': 'gompi', 'version': '2021a'}
+toolchain = {'name': 'gofb', 'version': '2021a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/TRIQS/triqs/releases/download/%(version)s/']
@@ -24,7 +24,6 @@ dependencies = [
     ('Boost', '1.76.0'),
     ('Clang', '13.0.1'),
     ('FFTW', '3.3.9'),
-    ('FlexiBLAS', '3.0.4'),
     ('HDF5', '1.12.1'),
 ]
 
@@ -34,17 +33,9 @@ builddependencies = [
     ('SciPy-Stack', '2021a'),
 ]
 
-multi_deps = {'Python': ['3.8', '3.9', '3.10.2']}
+multi_deps = {'Python': ['3.8', '3.9', '3.10']}
 
-# Remove installation directory before building. This fixes problems with
-# failing builds in the presence of preexisting installation.
-preconfigopts = [
-    'module load python/%(pyshortver)s scipy-stack && ' + \
-    'pip install mako==1.1.4 --no-index && ' + \
-    'rm -rf %(installdir)s && '
-]
-
-configopts = '-DBLA_VENDOR=FlexiBLAS'
+preconfigopts = 'pip install --prefix=%(builddir)s mako==1.1.4 && '
 
 separate_build_dir = True
 
@@ -62,11 +53,8 @@ sanity_check_commands = [
     "python -c 'import triqs'"
 ]
 
-modextrapaths = {
-    'CPLUS_INCLUDE_PATH': 'include',
-    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
-    'CMAKE_PREFIX_PATH': ['lib/cmake/triqs', 'lib/cmake/cpp2py']
-}
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
 modextravars = {
     'TRIQS_ROOT': '%(installdir)s',
     'TRIQS_VERSION': '%(version)s'

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
@@ -53,11 +53,6 @@ sanity_check_commands = [
     "python -c 'import triqs'"
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
-
-modextravars = {
-    'TRIQS_ROOT': '%(installdir)s',
-    'TRIQS_VERSION': '%(version)s'
-}
+modextrapaths = {'EBPYTHONPREFIXES': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
@@ -30,7 +30,7 @@ dependencies = [
 builddependencies = [
     ('CMake', '3.22.1'),
     ('mpi4py', '3.1.3'),
-    ('SciPy-Stack', '2021a'),
+    ('SciPy-Stack', '2022a'),
 ]
 
 multi_deps = {'Python': ['3.8', '3.9', '3.10']}
@@ -53,6 +53,6 @@ sanity_check_commands = [
     "python -c 'import triqs'"
 ]
 
-modextrapaths = {'EBPYTHONPREFIXES': ['lib/python%(pyshortver)s/site-packages']}
+modextrapaths = {'EBPYTHONPREFIXES': ['']}
 
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gofb-2021a.eb
@@ -34,16 +34,20 @@ builddependencies = [
     ('pytest', '7.0.1'),
 ]
 
-multi_deps = {'Python': ['3.9']}
+multi_deps = {'Python': ['3.8','3.9']}
 
-preconfigopts = 'PYTHONPATH=$PYTHONPATH:%(builddir)s/lib/python%(pyshortver)s/site-packages; '
-preconfigopts += 'pip install mako==1.1.4 --prefix=%(builddir)s/ && '
+preconfigopts = ' && '.join([
+    'PYTHONPATH=$PYTHONPATH:%(builddir)s/lib/python%(pyshortver)s/site-packages',
+    'pip install mako==1.1.4 --prefix=%(builddir)s/ && '
+])
 
-#I had to reinstall mako after installing TRIQS, even with separate_build_dir = False
-installopts = [
-    " && pip install --prefix=%(installdir)s mako==1.1.4 --no-index" +
-    " && /cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s/lib --any_interpreter --add_path %(installdir)s/lib"
-]
+#I had to reinstall mako after installing TRIQS
+#even when I installed it in the installdir or with
+#separate_build_dir = False
+installopts = ' && '.join([
+    " && pip install --prefix=%(installdir)s mako==1.1.4 --no-index",
+    "/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s/lib --any_interpreter --add_path %(installdir)s/lib"
+])
 
 separate_build_dir = True
 
@@ -55,50 +59,38 @@ exts_list = [
         'source_urls' : ['https://github.com/TRIQS/maxent/releases/download/%(version)s/'],
         'sources' : ['maxent-%(version)s.tar.gz'],
         'checksums' : ['87523adabdfe0c6d0a1fd84bdc1b4bceed64361adde922809d85e19c155e4c68'],
-        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
         'configopts': ' '.join([
             '-DBuild_Documentation=OFF',
             '-DMeasureG2=ON',
             '-DHybridisation_is_complex=ON',
             '-DLocal_hamiltonian_is_complex=ON',
         ]),
-        'runtest': 'test',
     }),
     ('triqs_cthyb', '3.1.0', {
         'source_urls' : ['https://github.com/TRIQS/cthyb/releases/download/%(version)s/'],
         'sources' : ['cthyb-%(version)s.tar.gz'],
         'checksums' : ['8d6d2c4d5b3928d062b72fad4ea9df9aae198e39dd9c1fd3cc5dc34a5019acc0'],
-        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
-        'runtest': 'test',
     }),
     ('triqs_hubbardI', '3.1.0', {
         'source_urls' : ['https://github.com/TRIQS/hubbardI/releases/download/%(version)s/'],
         'sources' : ['hubbardI-%(version)s.tar.gz'],
         'checksums' : ['a5748c90bfe4138f37c516fad5fb4cdc02bca3283a2328558d9c3224e0d372c7'],
-        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
-        'runtest' : 'test',
         'modulename' : 'triqs_hubbardI',
     }),
     ('triqs_tprf', '3.1.0', {
         'source_urls' : ['https://github.com/TRIQS/tprf/releases/download/%(version)s/'],
         'sources' : ['tprf-%(version)s.tar.gz'],
         'checksums' : ['75f6e79d891342951652353ea4d9914074d9947c67cad60844ebaa3f82bd17b5'],
-        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
-        'runtest': 'test',
     }),
     ('triqs_dft_tools', '3.1.0', { #https://triqs.github.io/dft_tools/
         'source_urls' : ['https://github.com/TRIQS/dft_tools/releases/download/%(version)s/'],
         'sources' : ['dft_tools-%(version)s.tar.gz'],
         'checksums' : ['57b7d0fe5a96c5a42bb684c60ca8e136a33e1385bf6cd7e9d1371fa507dc2ec4'],
-        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
-        'runtest': 'test',
     }),
     ('solid_dmft', '3.1.0', { #https://flatironinstitute.github.io/solid_dmft/      
         'source_urls' : ['https://github.com/flatironinstitute/solid_dmft/archive/refs/tags/'],
         'sources' : ['%(version)s.tar.gz'],
         'checksums' : ['ac2f73cd350349d76c1344e7eb16b7cc7372b5ab284e8cc8a5d31de531a844c1'],
-        'preconfigopts' : 'source $EBROOTTRIQS/share/triqs/triqsvars.sh && ',
-        'runtest': 'test',
     }),
 ]
 

--- a/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gompi-2021a.eb
+++ b/easybuild/easyconfigs/t/TRIQS/TRIQS-3.1.0-gompi-2021a.eb
@@ -1,0 +1,75 @@
+easyblock = 'CMakeMake'
+
+name = 'TRIQS'
+version = '3.1.0'
+
+homepage = 'https://triqs.github.io/triqs'
+description = """
+ TRIQS (Toolbox for Research on Interacting Quantum Systems) is a
+ scientific project providing a set of C++ and Python libraries to
+ develop new tools for the study of interacting quantum systems.
+"""
+
+docurls = ['https://triqs.github.io/triqs/%(version_major_minor)s.x/']
+software_license = 'LicenseGPLv3'
+
+toolchain = {'name': 'gompi', 'version': '2021a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/TRIQS/triqs/releases/download/%(version)s/']
+sources = ['triqs-%(version)s.tar.gz']
+checksums = ['f1f358ec73498bc7ac3ed9665829d8605908f7f7fc876a5c2a01efe37d368f0e']
+
+dependencies = [
+    ('Boost', '1.76.0'),
+    ('Clang', '13.0.1'),
+    ('FFTW', '3.3.9'),
+    ('FlexiBLAS', '3.0.4'),
+    ('HDF5', '1.12.1'),
+]
+
+builddependencies = [
+    ('CMake', '3.22.1'),
+    ('mpi4py', '3.1.3'),
+    ('SciPy-Stack', '2021a'),
+]
+
+multi_deps = {'Python': ['3.8', '3.9', '3.10.2']}
+
+# Remove installation directory before building. This fixes problems with
+# failing builds in the presence of preexisting installation.
+preconfigopts = [
+    'module load python/%(pyshortver)s scipy-stack && ' + \
+    'pip install mako==1.1.4 --no-index && ' + \
+    'rm -rf %(installdir)s && '
+]
+
+configopts = '-DBLA_VENDOR=FlexiBLAS'
+
+separate_build_dir = True
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/libtriqs.%s' % SHLIB_EXT],
+    'dirs': ['include/triqs', 'include/itertools', 'include/mpi', 'include/cpp2py',
+             'lib/python%(pyshortver)s/site-packages', 'share'],
+}
+
+sanity_check_commands = [
+    "triqs++ --help",
+    "c++2py --help",
+    "python -c 'import triqs'"
+]
+
+modextrapaths = {
+    'CPLUS_INCLUDE_PATH': 'include',
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+    'CMAKE_PREFIX_PATH': ['lib/cmake/triqs', 'lib/cmake/cpp2py']
+}
+modextravars = {
+    'TRIQS_ROOT': '%(installdir)s',
+    'TRIQS_VERSION': '%(version)s'
+}
+
+moduleclass = 'phys'


### PR DESCRIPTION
Add recipe to build TRIQS 3.1.0 and multi_deps for Python 3.8, 3.9, 3.10 (inspired from https://github.com/easybuilders/easybuild-easyconfigs/pull/15183).

However, build failed for Python 3.10 using multi_deps as Python binding seems not installed properly (reported by the sanity check, see attached log). Yet, the build for Python 3.10 works fine when adding Python 3.10.2 as a dependencies.

[triqs.log](https://github.com/ComputeCanada/easybuild-easyconfigs/files/8718063/triqs.log)

