### PR TITLE
add recipe for VTK-9.1.0 (scipy-stack 2022a, python 3.8, 3.9, 3.10)

### DIFF
--- a/easybuild/easyconfigs/v/VTK/VTK-9.1.0-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.1.0-GCC-9.3.0.eb
@@ -22,38 +22,32 @@ checksums = [
     'b9442cf1c30e1e44502e6dc36d3c6c2dc3d3f7d03306ee1d10737e9abadaa85d',  # VTKData-9.1.0.tar.gz
 ]
 
-#builddependencies = [('CMake', '3.12.3')]
 multi_deps = { 'Python': ['3.10', '3.9', '3.8'] }
 multi_deps_load_default = False
 modextrapaths = {'EBPYTHONPREFIXES': ['']}
 
 dependencies = [
     ('SciPy-Stack', '2022a'),
-    ('XZ', '5.2.5'),
-    ('HDF5', 'hdf5/1.10.6'),
+    ('HDF5', '1.10.6'),
     ('netCDF', '4.7.4'),
-    ('libGLU', '9.0.2'),
-    ('X11', '20210802'),
 ]
 
 separate_build_dir = True
 
-# Third party modules
-configopts = "-DVTK_USE_SYSTEM_LZMA=ON "
-configopts += "-DVTK_USE_SYSTEM_HDF5=ON "
-configopts += "-DVTK_USE_SYSTEM_NETCDF=ON "
-# OpenGL
-#configopts += "-DOPENGL_glu_LIBRARY=$NIXUSER_PROFILE/lib/libGLU.%s " % SHLIB_EXT
-#configopts += "-DOPENGL_gl_LIBRARY=$NIXUSER_PROFILE/lib/libGL.%s " % SHLIB_EXT
-#configopts += "-DOPENGL_INCLUDE_DIR=$NIXUSER_PROFILE/include "
-# Python
-configopts += "-DVTK_WRAP_PYTHON=ON "
-configopts += "-DVTK_PYTHON_VERSION=3 "
-configopts += "-DPYTHON_INCLUDE_DIR=$EBROOTPYTHON/include/python%(pyshortver)sm "
-configopts += "-DPYTHON_LIBRARY=$EBROOTPYTHON/lib/libpython%%(pyshortver)sm.%s " % SHLIB_EXT
-configopts += "-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python "
-# Other
-configopts += "-DCMAKE_INSTALL_LIBDIR=lib"
+configopts = ' '.join([
+    # Third party modules
+    "-DVTK_USE_SYSTEM_LZMA=ON",
+    "-DVTK_USE_SYSTEM_HDF5=ON",
+    "-DVTK_USE_SYSTEM_NETCDF=ON",
+    # Python
+    "-DVTK_WRAP_PYTHON=ON",
+    "-DVTK_PYTHON_VERSION=3",
+    "-DPYTHON_INCLUDE_DIR=$EBROOTPYTHON/include/python%(pyshortver)s",
+    "-DPYTHON_LIBRARY=$EBROOTPYTHON/lib/libpython%%(pyshortver)s.%s" % SHLIB_EXT,
+    "-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python",
+    # Other
+    "-DCMAKE_INSTALL_LIBDIR=lib",
+])
 
 preinstallopts = "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
 postinstallcmds = ['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s/lib --add_path %(installdir)s/lib --any_interpreter' ]

--- a/easybuild/easyconfigs/v/VTK/VTK-9.1.0-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.1.0-GCC-9.3.0.eb
@@ -1,0 +1,69 @@
+easyblock = 'CMakeMake'
+
+name = 'VTK'
+version = '9.1.0'
+
+homepage = 'http://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for
+ 3D computer graphics, image processing and visualization. VTK consists of a C++ class library and several
+ interpreted interface layers including Tcl/Tk, Java, and Python. VTK supports a wide variety of visualization
+ algorithms including: scalar, vector, tensor, texture, and volumetric methods; and advanced modeling techniques
+ such as: implicit modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay triangulation."""
+
+toolchain = {'name': 'GCC', 'version': '9.3.0'}
+
+source_urls = ['https://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    SOURCE_TAR_GZ,
+    '%(name)sData-%(version)s.tar.gz',
+]
+checksums = [
+    '8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96',  # VTK-9.1.0.tar.gz
+    'b9442cf1c30e1e44502e6dc36d3c6c2dc3d3f7d03306ee1d10737e9abadaa85d',  # VTKData-9.1.0.tar.gz
+]
+
+#builddependencies = [('CMake', '3.12.3')]
+multi_deps = { 'Python': ['3.10', '3.9', '3.8'] }
+multi_deps_load_default = False
+modextrapaths = {'EBPYTHONPREFIXES': ['']}
+
+dependencies = [
+    ('SciPy-Stack', '2022a'),
+    ('XZ', '5.2.5'),
+    ('HDF5', 'hdf5/1.10.6'),
+    ('netCDF', '4.7.4'),
+    ('libGLU', '9.0.2'),
+    ('X11', '20210802'),
+]
+
+separate_build_dir = True
+
+# Third party modules
+configopts = "-DVTK_USE_SYSTEM_LZMA=ON "
+configopts += "-DVTK_USE_SYSTEM_HDF5=ON "
+configopts += "-DVTK_USE_SYSTEM_NETCDF=ON "
+# OpenGL
+#configopts += "-DOPENGL_glu_LIBRARY=$NIXUSER_PROFILE/lib/libGLU.%s " % SHLIB_EXT
+#configopts += "-DOPENGL_gl_LIBRARY=$NIXUSER_PROFILE/lib/libGL.%s " % SHLIB_EXT
+#configopts += "-DOPENGL_INCLUDE_DIR=$NIXUSER_PROFILE/include "
+# Python
+configopts += "-DVTK_WRAP_PYTHON=ON "
+configopts += "-DVTK_PYTHON_VERSION=3 "
+configopts += "-DPYTHON_INCLUDE_DIR=$EBROOTPYTHON/include/python%(pyshortver)sm "
+configopts += "-DPYTHON_LIBRARY=$EBROOTPYTHON/lib/libpython%%(pyshortver)sm.%s " % SHLIB_EXT
+configopts += "-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python "
+# Other
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib"
+
+preinstallopts = "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
+postinstallcmds = ['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s/lib --add_path %(installdir)s/lib --any_interpreter' ]
+sanity_check_paths = {
+    'files': ['bin/vtk%s-%%(version_major_minor)s' % x for x in
+              ['WrapJava', 'ParseJava', 'WrapPythonInit', 'WrapPython', 'WrapHierarchy']] +
+             ['bin/vtkpython'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/', 'include/vtk-%(version_major_minor)s'],
+}
+
+sanity_check_commands = [('python', "-c 'import %(namelower)s'")]
+
+moduleclass = 'vis'


### PR DESCRIPTION
Add recipe for VTK-9.1.0 build with Scipy-Stack 2022a to support lastest numpy and Python versions.
Solve a dependencies conflict when using the Python package GemPy which need numpy>=1.20.