### PR TITLE
Bring SymEngine to Python 3.8 - 3.10 with new version 0.9.0

### DIFF
--- a/easybuild/easyconfigs/s/SymEngine/SymEngine-0.9.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/s/SymEngine/SymEngine-0.9.0-GCCcore-9.3.0.eb
@@ -1,0 +1,63 @@
+easyblock = 'CMakeMake'
+
+name = 'SymEngine'
+version = '0.9.0'
+
+homepage = 'https://github.com/symengine/symengine'
+description = "SymEngine is a standalone fast C++ symbolic manipulation library."
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/symengine/symengine/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['dcf174ac708ed2acea46691f6e78b9eb946d8a2ba62f75e87cf3bf4f0d651724']
+
+builddependencies = [
+    ('CMake', '3.21.4'),
+    ('SciPy-Stack', '2022a'),
+]
+
+dependencies = [
+    ('GMP', '6.2.0'),
+]
+
+configopts = " ".join([
+    "-DBUILD_SHARED_LIBS=ON",
+    "-DWITH_GMP=ON",
+    "-DWITH_MPFR=ON",
+    "-DWITH_MPC=ON",
+])
+
+multi_deps = {'Python': ['3.8', '3.9', '3.10']}
+
+multi_deps_extensions_only = True
+
+exts_defaultclass = 'PythonPackage'
+exts_list = [
+    ('symengine', '0.9.2', {
+        'sources': [{
+            'source_urls': ["https://github.com/symengine/symengine.py/releases/download/v%(version)s/"],
+            'filename': "symengine.py-0.9.2.tar.gz",
+        }],
+        'checksums': ['9da048692d741bb001d9947a0e2bdf8909600cb4e6f3b9273d518cf93300955d'],
+        'use_pip': True,
+    }),
+]
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+sanity_check_paths = {
+    'files': ['lib64/libsymengine.so'],
+    'dirs': ['include/symengine', 'lib/cmake/symengine', 'lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "python -c 'import symengine'",
+    "python -c 'from symengine import var;var(\"x y z\");e = (x+y+z)**2;e.expand();'",
+]
+
+modextrapaths = {
+    'EBPYTHONPREFIXES': '',
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Symengine required to build and install Python package qiskit, but it is not available for Python 3.10. Therefore, build the latest SymEngine release for Python 3.8 to 3.10.