### PR TITLE
RAPIDS AI

### DIFF
--- a/easybuild/easyconfigs/c/CUDAcore/CUDAcore-11.7.0.eb
+++ b/easybuild/easyconfigs/c/CUDAcore/CUDAcore-11.7.0.eb
@@ -16,28 +16,4 @@ source_urls = ['https://developer.download.nvidia.com/compute/cuda/%(version)s/l
 sources = ['cuda_%%(version)s_%s_linux%%(cudaarch)s.run' % local_nv_version]
 checksums = ['087fdfcbba1f79543b1f78e43a8dfdac5f6db242d042dde820e16dc185892f26']
 
-multi_deps = {'Python': ['3.8', '3.9', '3.10'] }
-multi_deps_extensions_only = True
-
-exts_defaultclass = 'PythonPackage'
-exts_list = [
-    ('cuda-python', '11.7.1', {
-        'modulename': 'cuda',
-        'source_urls': ['https://github.com/NVIDIA/cuda-python/archive/refs/tags'],
-        'sources': [{'filename': 'cuda-python-%(version)s.tar.gz', 'download_filename': 'v%(version)s.tar.gz'}],
-        'checksums': ['6a138fd2c831b668b80bc82251e3050c410d17f1ae3b36d0e00106a168ec36f0'],
-        'preinstallopts': 'pip install --no-index cython --prefix=%(installdir)s && ',
-        'installopts': ' ', # Make sure to override installopts inherited from EB_CUDA
-        'use_pip': True,
-    }),
-]
-exts_filter = ("python -c 'import %(ext_name)s'", '')
-
-sanity_check_commands = [
-    "python -c 'import cuda,cython'",
-    "python -c 'from cuda import cuda, cudart, nvrtc'",
-]
-
-modextrapaths = {'EBPYTHONPREFIXES':''}
-
 moduleclass = 'system'

--- a/easybuild/easyconfigs/c/CUDAcore/CUDAcore-11.7.0.eb
+++ b/easybuild/easyconfigs/c/CUDAcore/CUDAcore-11.7.0.eb
@@ -16,4 +16,28 @@ source_urls = ['https://developer.download.nvidia.com/compute/cuda/%(version)s/l
 sources = ['cuda_%%(version)s_%s_linux%%(cudaarch)s.run' % local_nv_version]
 checksums = ['087fdfcbba1f79543b1f78e43a8dfdac5f6db242d042dde820e16dc185892f26']
 
+multi_deps = {'Python': ['3.8', '3.9', '3.10'] }
+multi_deps_extensions_only = True
+
+exts_defaultclass = 'PythonPackage'
+exts_list = [
+    ('cuda-python', '11.7.1', {
+        'modulename': 'cuda',
+        'source_urls': ['https://github.com/NVIDIA/cuda-python/archive/refs/tags'],
+        'sources': [{'filename': 'cuda-python-%(version)s.tar.gz', 'download_filename': 'v%(version)s.tar.gz'}],
+        'checksums': ['6a138fd2c831b668b80bc82251e3050c410d17f1ae3b36d0e00106a168ec36f0'],
+        'preinstallopts': 'pip install --no-index cython --prefix=%(installdir)s && ',
+        'installopts': ' ', # Make sure to override installopts inherited from EB_CUDA
+        'use_pip': True,
+    }),
+]
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+sanity_check_commands = [
+    "python -c 'import cuda,cython'",
+    "python -c 'from cuda import cuda, cudart, nvrtc'",
+]
+
+modextrapaths = {'EBPYTHONPREFIXES':''}
+
 moduleclass = 'system'

--- a/easybuild/easyconfigs/d/dlpack/dlpack-0.7.eb
+++ b/easybuild/easyconfigs/d/dlpack/dlpack-0.7.eb
@@ -1,0 +1,42 @@
+easyblock = 'CMakeMake'
+
+name = 'dlpack'
+version = '0.7'
+
+homepage = 'https://dmlc.github.io/dlpack/latest/'
+description = """
+In order for an ndarray system to interact with a variety of frameworks, a stable in-memory data structure is needed.
+
+DLPack is one such data structure that allows exchange between major frameworks. It is developed with inputs from many deep learning system core developers. Highlights include:
+
+- Minimum and stable: simple header
+- Designed for cross hardware: CPU, CUDA, OpenCL, Vulkan, Metal, VPI, ROCm, WebGPU, Hexagon
+- Already a standard with wide community adoption and support:
+    * NumPy
+    * CuPy
+    * PyTorch
+    * Tensorflow
+    * MXNet
+    * TVM
+    * mpi4py
+- Clean C ABI compatible.
+    * Means you can create and access it from any language.
+    * It is also essential for building JIT and AOT compilers to support these data types.
+"""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/dmlc/dlpack/archive/refs/tags']
+sources = ['v%(version)s.tar.gz']
+checksums = ['13f60672b324d081545f423d720737121c4952a9b90bdd49dc372a84c3fe96ee']
+
+builddependencies = [
+    ('CMake', '3.23.1')
+]
+
+sanity_check_paths = {
+    'files': ['include/dlpack/dlpack.h'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
Work in progress to deploy RAPIDS 22.12 as a set of modules or python wheels.

Modules for RAPIDS
---
- [x] dlpack/0.7.2
- [x] spglog/1.9.2 -> https://github.com/ComputeCanada/easybuild-easyconfigs-installed-avx2/commit/664d2c1c147c6eca6864794a84403ee6b6226a4c
- [x] scikit-build/0.16.1 -> https://github.com/ComputeCanada/easybuild-easyconfigs-installed-avx2/commit/eeb56af0c96d13d68db3864d9d18596d2887c687
- [ ] cuda-python/11.7.0
- [ ] RMM/22.12
- [ ] cuDF/22.12
- [ ] RAFT/22.12
- [ ] CUB	
- [ ] libcudacxx	
- [ ] Thrust-RAPIDS/1.17.2
- [ ] cuCollections/	
- [ ] cuGraph/22.12
- [ ] cuML/22.12
- [ ] cuSignal/22.12
- [ ] RAPIDS/22.12
 