### PR TITLE
PRIMME-3.2: Fix last relative primme.h import for Python extension

### DIFF
--- a/easybuild/easyconfigs/p/PRIMME/PRIMME-3.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/PRIMME/PRIMME-3.2-GCCcore-9.3.0.eb
@@ -25,7 +25,7 @@ sources = ['v%(version)s.tar.gz']
 patches = ['PRIMME-3.2-fix-include-python.patch']
 checksums = [
     '8ff242a356cea465c9728a26cb6e0487712d9ae51050a362de487e3b13a2fe9b', #sources
-    '62f73a5ffbd6fd7908f055c51d0b01cce423d88cb2bbbacecea8977ee6691000', #patch
+    'bd26258eb2e2459f72b40e0e391da7d9cce08c6b3592628564073712310b53ac', #patch
 ]
 
 # No configure

--- a/easybuild/easyconfigs/p/PRIMME/PRIMME-3.2-fix-include-python.patch
+++ b/easybuild/easyconfigs/p/PRIMME/PRIMME-3.2-fix-include-python.patch
@@ -1,6 +1,6 @@
 diff -ru primme-3.2-old/Python/primme.c primme-3.2/Python/primme.c
 --- primme-3.2-old/Python/primme.c	2023-11-02 20:02:49.995355406 +0000
-+++ primme-3.2/Python/primme.c	2023-11-02 20:03:15.964583961 +0000
++++ primme-3.2/Python/primme.c	2023-11-27 15:27:23.188608546 +0000
 @@ -647,7 +647,7 @@
  
      /* NumPy API declarations from "numpy/__init__.pxd" */
@@ -39,7 +39,7 @@ diff -ru primme-3.2-old/Python/primme.c primme-3.2/Python/primme.c
   */
 diff -ru primme-3.2-old/Python/primme.pyx primme-3.2/Python/primme.pyx
 --- primme-3.2-old/Python/primme.pyx	2023-11-02 20:02:49.997355424 +0000
-+++ primme-3.2/Python/primme.pyx	2023-11-02 20:03:11.162541698 +0000
++++ primme-3.2/Python/primme.pyx	2023-11-27 15:28:40.415282930 +0000
 @@ -2,7 +2,7 @@
  
  import numpy as np
@@ -49,9 +49,27 @@ diff -ru primme-3.2-old/Python/primme.pyx primme-3.2/Python/primme.pyx
  cimport cython
  from cython cimport view
  try:
+@@ -52,7 +52,7 @@
+         return np.dtype(np.float64)
+ 
+ 
+-cdef extern from "../include/primme.h":
++cdef extern from "primme.h":
+     struct primme_params:
+         pass
+     ctypedef int primme_preset_method
+@@ -697,7 +697,7 @@
+ 
+ 
+ 
+-cdef extern from "../include/primme.h":
++cdef extern from "primme.h":
+     struct primme_svds_params:
+         pass
+     ctypedef int primme_svds_preset_method
 diff -ru primme-3.2-old/Python/setup.py primme-3.2/Python/setup.py
 --- primme-3.2-old/Python/setup.py	2023-11-02 20:02:49.998355433 +0000
-+++ primme-3.2/Python/setup.py	2023-11-02 20:03:23.772652679 +0000
++++ primme-3.2/Python/setup.py	2023-11-27 15:27:23.199608642 +0000
 @@ -43,7 +43,7 @@
         blaslapack_libraries = ['lapack', 'blas']
  


### PR DESCRIPTION
PRIMME 3.2 is still not building with ebuser as primme.h header is not find by its Python extension. Note it builds well locally. Last try before dropping Python extension ?