### PR TITLE
Fix KaHyPar recipe

### DIFF
--- a/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2-GCC-9.3.0.eb
@@ -26,7 +26,7 @@ patches = [
 checksums = [
     'd1a0681ff56d6b50ad5e00e10c26eb40f990ba401c1e28c6028d58d96783de75', #KaHyPar sources
     '883c2b54124504f7e360c3c2751d83a0a43917eb51eddf47c3321b76eea16b9a', #WHFC sources
-    '147d798ee752e4dede9a4a843ad5fa031eb8762a505fe3f6b2a0ba1b80bc46f3', #fix_install patch,
+    '60dd6959faaa55dce847cf3260475fa52aaea9b4365879f719a9515e4bdfb4fa', #fix_install patch,
     '1daed98fb010afd06d7754de78fc620e12eefab955e447ba4739f60157f51445', #fix_tests patch
 ]
 

--- a/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2-GCC-9.3.0.eb
@@ -26,7 +26,7 @@ patches = [
 checksums = [
     'd1a0681ff56d6b50ad5e00e10c26eb40f990ba401c1e28c6028d58d96783de75', #KaHyPar sources
     '883c2b54124504f7e360c3c2751d83a0a43917eb51eddf47c3321b76eea16b9a', #WHFC sources
-    '60dd6959faaa55dce847cf3260475fa52aaea9b4365879f719a9515e4bdfb4fa', #fix_install patch,
+    '4d2f23b401b41d6cd609b252a91f989ee3009d39760345ba2680bae7866fe900', #fix_install patch,
     '1daed98fb010afd06d7754de78fc620e12eefab955e447ba4739f60157f51445', #fix_tests patch
 ]
 

--- a/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2-GCC-9.3.0.eb
@@ -26,7 +26,7 @@ patches = [
 checksums = [
     'd1a0681ff56d6b50ad5e00e10c26eb40f990ba401c1e28c6028d58d96783de75', #KaHyPar sources
     '883c2b54124504f7e360c3c2751d83a0a43917eb51eddf47c3321b76eea16b9a', #WHFC sources
-    '599592bd0dc34c5c58f3fee9563169807a4423368a825cd72638c6e549a6bcbb', #fix_install patch,
+    '147d798ee752e4dede9a4a843ad5fa031eb8762a505fe3f6b2a0ba1b80bc46f3', #fix_install patch,
     '1daed98fb010afd06d7754de78fc620e12eefab955e447ba4739f60157f51445', #fix_tests patch
 ]
 

--- a/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2_fix_install.patch
+++ b/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2_fix_install.patch
@@ -1,6 +1,6 @@
 diff -ru kahypar-1.3.2.old/CMakeLists.txt kahypar-1.3.2/CMakeLists.txt
---- kahypar-1.3.2.old/CMakeLists.txt	2023-06-02 13:14:51.597699817 +0000
-+++ kahypar-1.3.2/CMakeLists.txt	2023-06-02 13:16:00.907224424 +0000
+--- kahypar-1.3.2.old/CMakeLists.txt	2023-04-08 15:08:04.000000000 -0400
++++ kahypar-1.3.2/CMakeLists.txt	2023-12-04 09:29:26.257858310 -0500
 @@ -17,9 +17,7 @@
  message(STATUS "Found Threads: ${CMAKE_THREAD_LIBS_INIT}")
  
@@ -20,9 +20,19 @@ diff -ru kahypar-1.3.2.old/CMakeLists.txt kahypar-1.3.2/CMakeLists.txt
  
  option(KAHYPAR_PYTHON_INTERFACE
    "Enable building the python interface" OFF)
+@@ -259,9 +258,6 @@
+     # M1 doesn't seem to support -mtune=native -march=native
+     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
+-  else()
+-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -mtune=native -march=native")
+-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -mtune=native -march=native -g3 ")
+   endif()
+ 
+ if(DEFINED ENV{TRAVIS_ENV})  
 diff -ru kahypar-1.3.2.old/python/CMakeLists.txt kahypar-1.3.2/python/CMakeLists.txt
---- kahypar-1.3.2.old/python/CMakeLists.txt	2023-06-02 12:58:59.786465212 +0000
-+++ kahypar-1.3.2/python/CMakeLists.txt	2023-06-02 13:16:33.120468249 +0000
+--- kahypar-1.3.2.old/python/CMakeLists.txt	2023-04-08 15:08:04.000000000 -0400
++++ kahypar-1.3.2/python/CMakeLists.txt	2023-12-04 09:27:26.318580579 -0500
 @@ -10,7 +10,7 @@
  #file(GLOB_RECURSE KAHYPAR_SOURCES RELATIVE ${PROJECT_SOURCE_DIR} *.h)
  

--- a/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2_fix_install.patch
+++ b/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2_fix_install.patch
@@ -20,12 +20,13 @@ diff -ru kahypar-1.3.2.old/CMakeLists.txt kahypar-1.3.2/CMakeLists.txt
  
  option(KAHYPAR_PYTHON_INTERFACE
    "Enable building the python interface" OFF)
-@@ -259,9 +258,6 @@
+@@ -259,9 +258,7 @@
      # M1 doesn't seem to support -mtune=native -march=native
      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
 -  else()
 -    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -mtune=native -march=native")
++    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 -    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -mtune=native -march=native -g3 ")
    endif()
  

--- a/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2_fix_install.patch
+++ b/easybuild/easyconfigs/k/KaHyPar/KaHyPar-1.3.2_fix_install.patch
@@ -20,11 +20,11 @@ diff -ru kahypar-1.3.2.old/CMakeLists.txt kahypar-1.3.2/CMakeLists.txt
  
  option(KAHYPAR_PYTHON_INTERFACE
    "Enable building the python interface" OFF)
-@@ -259,9 +258,7 @@
+@@ -259,9 +258,8 @@
      # M1 doesn't seem to support -mtune=native -march=native
      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 ")
--  else()
+   else()
 -    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -mtune=native -march=native")
 +    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 -    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -mtune=native -march=native -g3 ")


### PR DESCRIPTION
There was AVX512 instruction in the AVX2 version installed, because the -march=native flag was defined in the compilation. Fix the CMakeLists.txt in a patch.