### PR TITLE
WIP:  NCL 6.6.2 for StdEnv/2023

### DIFF
--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
@@ -1,0 +1,56 @@
+name = 'NCL'
+version = '6.6.2'
+
+homepage = 'https://www.ncl.ucar.edu'
+description = "NCL is an interpreted language designed specifically for scientific data analysis and visualization."
+
+toolchain = {'name': 'gofb', 'version': '2023a'}
+toolchainopts = {'cstd': 'c99', 'openmp': True, 'pic': True}
+
+source_urls = ['https://github.com/NCAR/ncl/archive/']
+sources = ['%(version)s.tar.gz']
+patches = [
+    'NCL-6.4.0_fix-types.patch',
+    'NCL-6.6.2_search_Gentoo_prefix.patch',
+    'NCL-6.6.2_use_HDF5v110_API.patch',
+]
+checksums = [
+    'cad4ee47fbb744269146e64298f9efa206bc03e7b86671e9729d8986bb4bc30e',  # 6.6.2.tar.gz
+    'f6dfaf95e5de9045745e122cb44f9c035f81fab92f5892991ddfe93945891c8f',  # NCL-6.4.0_fix-types.patch
+    '036b948f6a7fe6e3250775b8fe22414b7d5c3ca438728f548ca07d8bc8332e2d',  # NCL-6.6.2_search_Gentoo_prefix.patch
+    'd97b48f5fefbc55c6eed9416dfeed910d9070a4478118d0e1abcdd775fcb0a70',  # NCL-6.6.2_use_HDF5v110_API.patch
+]
+
+configopts = " -DH5_USE_110_API_DEFAULT=1 "
+
+preinstallopts = "CPATH=$EBROOTGENTOO/include/freetype2:$CPATH GENTOO_GCC_INCLUDE=${EBROOTGENTOO}/lib/gcc/x86_64-pc-linux-gnu/12/include "
+
+builddependencies = [
+    ('makedepend', '1.0.6'),
+    ('Bison', '3.8.2'),
+    ('flex', '2.6.4'),
+]
+dependencies = [
+    ('cURL', '7.69.1'),
+    ('JasPer', '4.0.0'),
+    ('g2lib', '3.4.8'),
+    ('g2clib', '1.8.0'),
+    ('HDF', '4.2.16'),
+    ('HDF5', '1.14.2'),
+    ('netCDF', '4.9.2'),
+    ('netCDF-Fortran', '4.6.1'),
+    ('Szip', '2.1.1'),
+    ('freetype', '2.10.1'),
+    ('zlib', '1.2.11'),
+    ('GDAL', '3.7.2'),
+    ('UDUNITS', '2.2.28'),
+    ('ESMF', '8.6.0'),
+    ('bzip2', '1.0.8'),
+    ('cairo', '1.16.0'),
+    ('libiconv', '1.16'),
+    ('GSL', '2.7'),
+    ('libpng', '1.6.37'),
+    ('libjpeg-turbo', '2.0.4'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2_search_Gentoo_prefix.patch
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2_search_Gentoo_prefix.patch
@@ -1,0 +1,24 @@
+Patch to add the Gentoo-prefix to the library and include search path.
+
+Note:
+The variable GENTOO_GCC_INCLUDE needs to be set in the preinstallopts inside the easyconfig.
+We can't set it directly inside of this Template, otherwise the path gets mangled, because
+some components of it happen do have the same name as some define statements.
+
+author: Oliver Stueker (ACENET)
+date:   2023-12-12
+diff --git a/config/Template b/config/Template
+index a5f1e38..7efcd42 100644
+--- a/config/Template
++++ b/config/Template
+@@ -620,8 +620,8 @@ PYTHONINCSEARCH		= PythonIncSearch
+ PYTHONPKGSDIR           = PythonPkgsDir
+ PYTHONBINDIR            = PythonBinDir
+ 
+-LIB_SEARCH		= $(LIBSEARCH) ExtraLibSearch
+-INC_SEARCH		= $(INCSEARCH) ExtraIncSearch
++LIB_SEARCH		= $(LIBSEARCH) ExtraLibSearch  -L$(EBROOTGENTOO)/lib64
++INC_SEARCH		= $(INCSEARCH) ExtraIncSearch  -I$(GENTOO_GCC_INCLUDE)  -I$(EBROOTGENTOO)/include
+ 
+ TOP			= TOPDIR
+ CURRENT_DIR		= CURDIR

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2_use_HDF5v110_API.patch
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2_use_HDF5v110_API.patch
@@ -1,0 +1,17 @@
+Patch to use HDF5 Function/struct mapping of HDF5 v 1.10.x.
+https://docs.hdfgroup.org/hdf5/develop/api-compat-macros.html
+author: Oliver Stueker (ACENET)
+date:   2023-12-12
+diff --git a/config/Template b/config/Template
+index a5f1e38..7b5f588 100644
+--- a/config/Template
++++ b/config/Template
+@@ -712,7 +712,7 @@ CSTATIC		= Cstatic
+ /*
+  *CCOPTIONS	= CcOptions $(EXTRA_CCOPTIONS) -framework OpenCL
+  */
+-CCOPTIONS	= CcOptions $(EXTRA_CCOPTIONS)
++CCOPTIONS	= CcOptions $(EXTRA_CCOPTIONS) -DH5_USE_110_API_DEFAULT=1
+ 
+ BUILDINCDIR	= $(TOP)/include
+ /*


### PR DESCRIPTION
This PR is still a Work-in-progress as it's producing errors like:

```
make[3]: Entering directory '/tmp/stuekero/avx2/NCL/6.6.2/gofb-2023a/ncl-6.6.2/external/fftpack5_dp'
gfortran -O2 -ftree-vectorize -march=x86-64-v3 -fno-math-errno -fopenmp -fPIC  -O2 -ftree-vectorize -march=x86-64-v3 -fno-math-errno -fopenmp -fPIC    -c -o c1fm1b.o c1fm1b.f
c1fm1b.f:35:33:

   33 |    52     CALL DC1F2KB(IDO,L1,NA,C,INC2,CH,2,WA(IW))
      |                                 2
   34 |           GO TO 120
   35 |    62     CALL DC1F2KB(IDO,L1,NA,CH,2,C,INC2,WA(IW))
      |                                 1
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/COMPLEX(8)).
c1fm1b.f:35:38:

   33 |    52     CALL DC1F2KB(IDO,L1,NA,C,INC2,CH,2,WA(IW))
      |                                        2
   34 |           GO TO 120
   35 |    62     CALL DC1F2KB(IDO,L1,NA,CH,2,C,INC2,WA(IW))
      |                                      1
Error: Type mismatch between actual argument at (1) and actual argument at (2) (COMPLEX(8)/REAL(8)).
[...]
```

and:

```
Making install in ./common/src/libncarg_c
make[4]: Entering directory '/tmp/stuekero/avx2/NCL/6.6.2/gofb-2023a/ncl-6.6.2/common/src/libncarg_c'
gcc -ansi -O2 -ftree-vectorize -march=x86-64-v3 -fno-math-errno -fopenmp -fPIC -std=c99  -DH5_USE_110_API_DEFAULT=1 -O2 -ftree-vectorize -march=x86-64-v3 -fno-math-errno -fopenmp -fPIC -std=c99  -I../../.././include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/hdf5-mpi/1.14.2/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/jasper/4.0.0/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/netcdf-mpi/4.9.2/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/hdf/4.2.16/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/g2clib/1.8.0/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/udunits/2.2.28/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/netcdf-fortran-mpi/4.6.1/include  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcc12/gdal/3.7.2/include   -I/cvmfs/soft.computecanada.ca/gentoo/2023/x86-64-v3/usr/lib/gcc/x86_64-pc-linux-gnu/12/include  -I/cvmfs/soft.computecanada.ca/gentoo/2023/x86-64-v3/usr/include  -DLinux  -DIBM -DNGVERSION='"6.6.2"'  -DNCLVERSION='"6.6.2"'  -DNCARGURL='"ngurl"'  -DSYSV -D_POSIX_SOURCE -D_XOPEN_SOURCE -DByteSwapped -DNeedFuncProto  -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcc12/gsl/2.7/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/esmf/8.6.0/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/udunits/2.2.28/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcc12/gdal/3.7.2/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/netcdf-fortran-mpi/4.6.1/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/netcdf-mpi/4.9.2/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/MPI/gcc12/openmpi4/hdf5-mpi/1.14.2/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/hdf/4.2.16/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/g2clib/1.8.0/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Compiler/gcccore/jasper/4.0.0/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Core/flexiblascore/3.3.1/include -I/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Core/flexiblascore/3.3.1/include/flexiblas  -c -o logic32.o logic32.c
gfortran -O2 -ftree-vectorize -march=x86-64-v3 -fno-math-errno -fopenmp -fPIC  -O2 -ftree-vectorize -march=x86-64-v3 -fno-math-errno -fopenmp -fPIC    -c -o r1mach.o r1mach.f
r1mach.f:167:27:

  167 |                CALL I1MCRA(SMALL, K, 16, 0, 0)
      |                           1
Error: Rank mismatch in argument a at (1) (scalar and rank-1)
r1mach.f:168:27:

  168 |                CALL I1MCRA(LARGE, K, 32751, 16777215, 16777215)
      |                           1
Error: Rank mismatch in argument a at (1) (scalar and rank-1)
r1mach.f:169:27:

  169 |                CALL I1MCRA(RIGHT, K, 15520, 0, 0)
      |                           1
Error: Rank mismatch in argument a at (1) (scalar and rank-1)
r1mach.f:170:27:

  170 |                CALL I1MCRA(DIVER, K, 15536, 0, 0)
      |                           1
Error: Rank mismatch in argument a at (1) (scalar and rank-1)
r1mach.f:171:27:

  171 |                CALL I1MCRA(LOG10, K, 16339, 4461392, 10451455)
      |                           1
Error: Rank mismatch in argument a at (1) (scalar and rank-1)
make[4]: *** [<builtin>: r1mach.o] Error 1
make[4]: Leaving directory '/tmp/stuekero/avx2/NCL/6.6.2/gofb-2023a/ncl-6.6.2/common/src/libncarg_c'
```