### PR TITLE
NCL 6.6.2 for StdEnv/2023

### DIFF
--- a/easybuild/easyconfigs/g/g2clib/g2clib-1.8.0-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/g/g2clib/g2clib-1.8.0-GCCcore-12.3.0.eb
@@ -27,8 +27,13 @@ dependencies = [
 
 configopts = ' -DUSE_AEC=ON '
 
+postinstallcmds = [
+    # NCL expects this to be named libgrib2c.a instead of libg2c.a
+    'cd %(installdir)s/lib64 && ln -s libg2c.a libgrib2c.a',
+]
+
 sanity_check_paths = {
-    'files': [],
+    'files': ['lib/libg2c.a', 'lib/libgrib2c.a', 'include/grib2.h'],
     'dirs': ['include'],
 }
 

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
@@ -20,6 +20,7 @@ patches = [
     'NCL-6.6.2_multiple_definitions.patch',
     'NCL-6.6.2_search_Gentoo_prefix.patch',
     'NCL-6.6.2_use_HDF5v110_API.patch',
+    'NCL-6.6.2_link_libaec.patch',
 ]
 checksums = [
     'cad4ee47fbb744269146e64298f9efa206bc03e7b86671e9729d8986bb4bc30e',  # 6.6.2.tar.gz
@@ -28,6 +29,7 @@ checksums = [
     'e21503dc46fe6fd360ba7ca4897aa93bf9ec2961bc48634ca46de582710448f7',  # NCL-6.6.2_multiple_definitions.patch
     '036b948f6a7fe6e3250775b8fe22414b7d5c3ca438728f548ca07d8bc8332e2d',  # NCL-6.6.2_search_Gentoo_prefix.patch
     'd97b48f5fefbc55c6eed9416dfeed910d9070a4478118d0e1abcdd775fcb0a70',  # NCL-6.6.2_use_HDF5v110_API.patch
+    'c265497049a22d6a7e05d5588a361e7bccf44d359f2f033c05db307ac996ac82',  # NCL-6.6.2_link_libaec.patch
 ]
 
 configopts = " -DH5_USE_110_API_DEFAULT=1 "

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
@@ -5,18 +5,27 @@ homepage = 'https://www.ncl.ucar.edu'
 description = "NCL is an interpreted language designed specifically for scientific data analysis and visualization."
 
 toolchain = {'name': 'gofb', 'version': '2023a'}
-toolchainopts = {'cstd': 'c99', 'openmp': True, 'pic': True}
+toolchainopts = {
+    'cstd': 'c99', 'openmp': True, 'pic': True,
+    # as suggested in https://github.com/NCAR/ncl/issues/123#issuecomment-650691723 
+    # add flags to ignore errors of newer gfortran compilers.
+    'extra_fflags': '-std=legacy -fallow-invalid-boz -fallow-argument-mismatch',
+}
 
 source_urls = ['https://github.com/NCAR/ncl/archive/']
 sources = ['%(version)s.tar.gz']
 patches = [
     'NCL-6.4.0_fix-types.patch',
+    'NCL-6.6.2_header_and_operands.patch',
+    'NCL-6.6.2_multiple_definitions.patch',
     'NCL-6.6.2_search_Gentoo_prefix.patch',
     'NCL-6.6.2_use_HDF5v110_API.patch',
 ]
 checksums = [
     'cad4ee47fbb744269146e64298f9efa206bc03e7b86671e9729d8986bb4bc30e',  # 6.6.2.tar.gz
     'f6dfaf95e5de9045745e122cb44f9c035f81fab92f5892991ddfe93945891c8f',  # NCL-6.4.0_fix-types.patch
+    '5cb62d9a37de8af485b94487692f7e739ca5eb103a6b447e0290a68a6c094808',  # NCL-6.6.2_header_and_operands.patch
+    'e21503dc46fe6fd360ba7ca4897aa93bf9ec2961bc48634ca46de582710448f7',  # NCL-6.6.2_multiple_definitions.patch
     '036b948f6a7fe6e3250775b8fe22414b7d5c3ca438728f548ca07d8bc8332e2d',  # NCL-6.6.2_search_Gentoo_prefix.patch
     'd97b48f5fefbc55c6eed9416dfeed910d9070a4478118d0e1abcdd775fcb0a70',  # NCL-6.6.2_use_HDF5v110_API.patch
 ]

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
@@ -9,7 +9,7 @@ toolchainopts = {
     'cstd': 'c99', 'openmp': True, 'pic': True,
     # as suggested in https://github.com/NCAR/ncl/issues/123#issuecomment-650691723 
     # add flags to ignore errors of newer gfortran compilers.
-    'extra_fflags': '-std=legacy -fallow-invalid-boz -fallow-argument-mismatch',
+    'extra_fflags': '-fallow-invalid-boz -fallow-argument-mismatch',
 }
 
 source_urls = ['https://github.com/NCAR/ncl/archive/']
@@ -31,8 +31,6 @@ checksums = [
     'd97b48f5fefbc55c6eed9416dfeed910d9070a4478118d0e1abcdd775fcb0a70',  # NCL-6.6.2_use_HDF5v110_API.patch
     'c265497049a22d6a7e05d5588a361e7bccf44d359f2f033c05db307ac996ac82',  # NCL-6.6.2_link_libaec.patch
 ]
-
-configopts = " -DH5_USE_110_API_DEFAULT=1 "
 
 preinstallopts = "CPATH=$EBROOTGENTOO/include/freetype2:$CPATH GENTOO_GCC_INCLUDE=${EBROOTGENTOO}/lib/gcc/x86_64-pc-linux-gnu/12/include "
 

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2-gofb-2023a.eb
@@ -1,0 +1,56 @@
+name = 'NCL'
+version = '6.6.2'
+
+homepage = 'https://www.ncl.ucar.edu'
+description = "NCL is an interpreted language designed specifically for scientific data analysis and visualization."
+
+toolchain = {'name': 'gofb', 'version': '2023a'}
+toolchainopts = {'cstd': 'c99', 'openmp': True, 'pic': True}
+
+source_urls = ['https://github.com/NCAR/ncl/archive/']
+sources = ['%(version)s.tar.gz']
+patches = [
+    'NCL-6.4.0_fix-types.patch',
+    'NCL-6.6.2_search_Gentoo_prefix.patch',
+    'NCL-6.6.2_use_HDF5v110_API.patch',
+]
+checksums = [
+    'cad4ee47fbb744269146e64298f9efa206bc03e7b86671e9729d8986bb4bc30e',  # 6.6.2.tar.gz
+    'f6dfaf95e5de9045745e122cb44f9c035f81fab92f5892991ddfe93945891c8f',  # NCL-6.4.0_fix-types.patch
+    '036b948f6a7fe6e3250775b8fe22414b7d5c3ca438728f548ca07d8bc8332e2d',  # NCL-6.6.2_search_Gentoo_prefix.patch
+    'd97b48f5fefbc55c6eed9416dfeed910d9070a4478118d0e1abcdd775fcb0a70',  # NCL-6.6.2_use_HDF5v110_API.patch
+]
+
+configopts = " -DH5_USE_110_API_DEFAULT=1 "
+
+preinstallopts = "CPATH=$EBROOTGENTOO/include/freetype2:$CPATH GENTOO_GCC_INCLUDE=${EBROOTGENTOO}/lib/gcc/x86_64-pc-linux-gnu/12/include "
+
+builddependencies = [
+    ('makedepend', '1.0.6'),
+    ('Bison', '3.8.2'),
+    ('flex', '2.6.4'),
+]
+dependencies = [
+    ('cURL', '7.69.1'),
+    ('JasPer', '4.0.0'),
+    ('g2lib', '3.4.8'),
+    ('g2clib', '1.8.0'),
+    ('HDF', '4.2.16'),
+    ('HDF5', '1.14.2'),
+    ('netCDF', '4.9.2'),
+    ('netCDF-Fortran', '4.6.1'),
+    ('Szip', '2.1.1'),
+    ('freetype', '2.10.1'),
+    ('zlib', '1.2.11'),
+    ('GDAL', '3.7.2'),
+    ('UDUNITS', '2.2.28'),
+    ('ESMF', '8.6.0'),
+    ('bzip2', '1.0.8'),
+    ('cairo', '1.16.0'),
+    ('libiconv', '1.16'),
+    ('GSL', '2.7'),
+    ('libpng', '1.6.37'),
+    ('libjpeg-turbo', '2.0.4'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2_link_libaec.patch
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2_link_libaec.patch
@@ -1,0 +1,32 @@
+Make sure to link to libaec.
+
+author: Oliver Stueker (ACENET)
+date:   2024-01-18
+diff -u --recursive ncl-6.6.2.orig/.build/Site.local.template ncl-6.6.2/.build/Site.local.template
+--- ncl-6.6.2.orig/.build/Site.local.template	2019-02-27 20:14:39.000000000 -0330
++++ ncl-6.6.2/.build/Site.local.template	2024-01-18 11:43:56.287631825 -0330
+@@ -13,9 +13,9 @@
+ 
+ #define HDF5lib -lhdf5_hl -lhdf5 -lz
+ #define NetCDF4lib  -lhdf5_hl -lhdf5
+-#define GRIB2lib ${grib2_dir}/libgrib2c.a -ljasper -lpng -lz -ljpeg
++#define GRIB2lib ${grib2_dir}/libgrib2c.a -ljasper -lpng -lz -ljpeg -laec
+ /* libgdal contains its own libgrib2c, so the proper libgrib2c should always be linked before libgdal. */
+-#define GDALlib  ${grib2_dir}/libgrib2c.a -lgdal -lproj -ljpeg
++#define GDALlib  ${grib2_dir}/libgrib2c.a -lgdal -lproj -ljpeg -laec
+ #define LexLibrary  ${PREFIX}/lib/libfl.a
+ 
+ ${CAIROLIB}
+diff -u --recursive ncl-6.6.2.orig/config/Project ncl-6.6.2/config/Project
+--- ncl-6.6.2.orig/config/Project	2019-02-27 20:14:39.000000000 -0330
++++ ncl-6.6.2/config/Project	2024-01-18 11:45:01.575555673 -0330
+@@ -302,7 +302,7 @@
+ #endif
+ 
+ #ifndef	GRIB2lib
+-#define       GRIB2lib   -lgrib2c -ljasper -lpng -lz -ljpeg
++#define       GRIB2lib   -lgrib2c -ljasper -lpng -lz -ljpeg -laec
+ #endif	/* GRIB2lib */
+ 
+ #ifndef	EEMDlib
+

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2_search_Gentoo_prefix.patch
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2_search_Gentoo_prefix.patch
@@ -1,0 +1,24 @@
+Patch to add the Gentoo-prefix to the library and include search path.
+
+Note:
+The variable GENTOO_GCC_INCLUDE needs to be set in the preinstallopts inside the easyconfig.
+We can't set it directly inside of this Template, otherwise the path gets mangled, because
+some components of it happen do have the same name as some define statements.
+
+author: Oliver Stueker (ACENET)
+date:   2023-12-12
+diff --git a/config/Template b/config/Template
+index a5f1e38..7efcd42 100644
+--- a/config/Template
++++ b/config/Template
+@@ -620,8 +620,8 @@ PYTHONINCSEARCH		= PythonIncSearch
+ PYTHONPKGSDIR           = PythonPkgsDir
+ PYTHONBINDIR            = PythonBinDir
+ 
+-LIB_SEARCH		= $(LIBSEARCH) ExtraLibSearch
+-INC_SEARCH		= $(INCSEARCH) ExtraIncSearch
++LIB_SEARCH		= $(LIBSEARCH) ExtraLibSearch  -L$(EBROOTGENTOO)/lib64
++INC_SEARCH		= $(INCSEARCH) ExtraIncSearch  -I$(GENTOO_GCC_INCLUDE)  -I$(EBROOTGENTOO)/include
+ 
+ TOP			= TOPDIR
+ CURRENT_DIR		= CURDIR

--- a/easybuild/easyconfigs/n/NCL/NCL-6.6.2_use_HDF5v110_API.patch
+++ b/easybuild/easyconfigs/n/NCL/NCL-6.6.2_use_HDF5v110_API.patch
@@ -1,0 +1,17 @@
+Patch to use HDF5 Function/struct mapping of HDF5 v 1.10.x.
+https://docs.hdfgroup.org/hdf5/develop/api-compat-macros.html
+author: Oliver Stueker (ACENET)
+date:   2023-12-12
+diff --git a/config/Template b/config/Template
+index a5f1e38..7b5f588 100644
+--- a/config/Template
++++ b/config/Template
+@@ -712,7 +712,7 @@ CSTATIC		= Cstatic
+ /*
+  *CCOPTIONS	= CcOptions $(EXTRA_CCOPTIONS) -framework OpenCL
+  */
+-CCOPTIONS	= CcOptions $(EXTRA_CCOPTIONS)
++CCOPTIONS	= CcOptions $(EXTRA_CCOPTIONS) -DH5_USE_110_API_DEFAULT=1
+ 
+ BUILDINCDIR	= $(TOP)/include
+ /*


### PR DESCRIPTION
**Updated 2024-01-18:**

Okay it builds, but it's not pretty.

1. HDF5 v1.14.2 has changed it's API, however NCL 6.6.2 (there wasn't any release since Feb 2019) uses the HDF5 v1.10.x API. The `NCL-6.6.2_use_HDF5v110_API.patch` takes care of that.
2. NCL's build process doesn't look into GENTOO prefix and failed to find headers and libraries that we don't install with easybuild.  `NCL-6.6.2_search_Gentoo_prefix.patch` and `preinstallopts` take care of that.  
  Setting the variable `GENTOO_GCC_INCLUDE` in the `preinstallopts` and patching `ncl/config/Template` to use that variable is necessary, because when the PATH is patched directly into the `Template`, it gets mangled because a substring of it, matches a define statement and gets replaced.
3. The errors `Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/COMPLEX(8)).` and `Rank mismatch in argument a at (1) (scalar and rank-1)` were addressed by adding 'extra_fflags': ' -fallow-invalid-boz -fallow-argument-mismatch', to the `toolchainopts`.
4. Errors `Operands of binary numeric operator / at (1) are INTEGER(4)/BOZ` were resolved by applying `NCL-6.6.2_header_and_operands.patch`
5. Adding the creation of a (compat) symbolic link `libgrib2c.a -> libg2c.a` to `g2clib-1.8.0.eb` makes sure that NCL can find that library under its old name.
6. Finally NCL needs to be convinced to link to `libaec`, because `g2clib-1.8.0.eb` is being compiled with `libaec` support (and NCL links statically to it). `NCL-6.6.2_link_libaec.patch` does that.