### PR TITLE
Adapting tblite 0.3.0 recipe to use shared libraries

### DIFF
--- a/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
+++ b/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
@@ -24,8 +24,11 @@ dependencies = [
     ('mctc-lib', '0.3.1'),
     ('mstore', '0.2.0'),
     ('simple-dftd3', '1.0.0'),
-    ('dftd4', '3.6.0')
+    ('dftd4', '3.6.0'),
+    ('xtb', '6.6.1'),
 ]
+
+configopts = "-DBUILD_SHARED_LIBS=ON "
 
 multi_deps = {'Python': ['3.10', '3.11']}
 multi_deps_extensions_only = True
@@ -44,16 +47,17 @@ exts_list = [
             '48654770b2681a354d9f6a849c5bc903b94a18c39c25c61754807d8add1ad7a9',
             'be04116d444c3bd526bb3521981d773fa5af5c2b82fb5c9f31ba528d6fec4e40',
         ],
-        'prebuildopts': ' export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && ',
+        'prebuildopts': ' export CC=gcc && export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && ',
         'use_pip': True,
     }),
 ]
-exts_filter = ("module load scipy-stack && python -c 'import %(ext_name)s'", '')
+
+exts_filter = ("module load scipy-stack/2023b && python -c 'import %(ext_name)s' && python -c 'import tblite.ase'", '')
 
 modextrapaths = {'EBPYTHONPREFIXES': '' }
 
 sanity_check_paths = {
-    'files': ['bin/%(name)s', 'include/%(name)s.h', 'lib/lib%(name)s.a'],
+    'files': ['bin/%(name)s', 'include/%(name)s.h', 'lib/lib%(name)s.so'],
     'dirs': ['share'],
 }
 

--- a/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
+++ b/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
@@ -49,6 +49,7 @@ exts_list = [
         ],
         'prebuildopts': ' export CC=gcc && export PKG_CONFIG_PATH=%(installdir)s/lib/pkgconfig:$PKG_CONFIG_PATH && ',
         'use_pip': True,
+        'sanity_pip_check': False,
     }),
 ]
 

--- a/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
+++ b/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
@@ -27,7 +27,12 @@ dependencies = [
     ('dftd4', '3.6.0'),
 ]
 
-configopts = "-DBUILD_SHARED_LIBS=ON "
+local_common_configopts = ''
+# perform iterative build to get both static and shared libraries
+configopts = [
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=ON',
+    local_common_configopts + ' -DBUILD_SHARED_LIBS=OFF',
+]
 
 multi_deps = {'Python': ['3.10', '3.11']}
 multi_deps_extensions_only = True
@@ -57,7 +62,7 @@ exts_filter = ("module load scipy-stack/2023b && python -c 'import %(ext_name)s'
 modextrapaths = {'EBPYTHONPREFIXES': '' }
 
 sanity_check_paths = {
-    'files': ['bin/%(name)s', 'include/%(name)s.h', 'lib/lib%(name)s.so'],
+    'files': ['bin/%(name)s', 'include/%(name)s.h', 'lib/lib%(name)s.so', 'lib/lib%(name)s.a'],
     'dirs': ['share'],
 }
 

--- a/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
+++ b/easybuild/easyconfigs/t/tblite/tblite-0.3.0-gccflexiblas-2023a.eb
@@ -25,7 +25,6 @@ dependencies = [
     ('mstore', '0.2.0'),
     ('simple-dftd3', '1.0.0'),
     ('dftd4', '3.6.0'),
-    ('xtb', '6.6.1'),
 ]
 
 configopts = "-DBUILD_SHARED_LIBS=ON "
@@ -53,7 +52,7 @@ exts_list = [
     }),
 ]
 
-exts_filter = ("module load scipy-stack/2023b && python -c 'import %(ext_name)s' && python -c 'import tblite.ase'", '')
+exts_filter = ("module load scipy-stack/2023b && python -c 'import %(ext_name)s' && module load xtb/6.6.1 && python -c 'import tblite.ase'", '')
 
 modextrapaths = {'EBPYTHONPREFIXES': '' }
 


### PR DESCRIPTION
Static libraries are missing some symbols for the subsequent python libraries for some reason. Switching to shared libs resolves this. Additional changes to check the import in a sanity check.