### PR TITLE
OpenFOAM v2412

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-cleanup.patch
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2406-cleanup.patch
@@ -1,0 +1,182 @@
+# Replaces OpenFOAM third-party libraries with EASYBUILD variants.
+# Uses the OpenFOAM prefs mechanism and the FOAM_CONFIG_ETC variable
+# to define the preferred settings without patching the original files
+#
+# Authors: Mark Olesen <Mark.Olesen@esi-group.com>
+#
+# ChangeLog:
+# - v2312 - activate METIS, KaHIP and readline support in etc/config.sh/setup
+#           author: Jiri Furst <jiri.furst@gmail.com>
+# - v2406 - set MPFR_ARCH_PATH and GMP_ARCH_PATH to CGAL config
+#           author: Jiri Furst <jiri.furst@gmail.com>
+#
+# -------------------------------------------------------------------------
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/prefs.sh	2020-12-14 10:02:26.488430802 +0100
+@@ -0,0 +1,7 @@
++##Easybuild## settings -*- sh -*-
++
++export FOAM_CONFIG_ETC="etc/easybuild"
++
++export WM_MPLIB=EASYBUILDMPI
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/CGAL	2020-12-14 10:10:55.991841204 +0100
+@@ -0,0 +1,8 @@
++##Easybuild## settings -*- sh -*-
++
++export MPFR_ARCH_PATH="$EBROOTMPFR"
++export GMP_ARCH_PATH="$EBROOTGMP"
++export BOOST_ARCH_PATH="$EBROOTBOOST"
++export CGAL_ARCH_PATH="$EBROOTCGAL"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/FFTW	2020-12-14 10:10:53.735843322 +0100
+@@ -0,0 +1,5 @@
++##Easybuild## settings -*- sh -*-
++
++export FFTW_ARCH_PATH="$EBROOTFFTW"
++
++##EasyBuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/metis	2020-12-11 21:23:28.774934024 +0100
+@@ -0,0 +1,6 @@
++##Easybuild## settings -*- sh -*-
++
++METIS_VERSION="metis-$EBVERSIONMETIS"
++[ -d "$METIS_ARCH_PATH" ] || METIS_ARCH_PATH="$EBROOTMETIS"
++
++##Easybuild##
+--- /dev/null   2022-12-01 18:21:35.103878336 +0100
++++ OpenFOAM-v2206/etc/easybuild/config.sh/kahip       2022-12-12 20:24:07.538408981 +0100
+@@ -0,0 +1,6 @@
++##Easybuild## settings -*- sh -*-
++
++KAHIP_VERSION="kahip-$EBVERSIONKAHIP"
++export KAHIP_ARCH_PATH="$EBROOTKAHIP"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/readline	2020-12-11 21:23:22.534951043 +0100
+@@ -0,0 +1,5 @@
++##Easybuild## settings -*- sh -*-
++
++export READLINE_ARCH_PATH="$EBROOTLIBREADLINE"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/scotch	2020-12-11 21:23:17.586964539 +0100
+@@ -0,0 +1,7 @@
++##Easybuild## settings -*- sh -*-
++
++export SCOTCH_VERSION="scotch_$EBVERSIONSCOTCH"
++export SCOTCH_ARCH_PATH="$EBROOTSCOTCH"
++[ -d "$SCOTCH_ARCH_PATH" ] || SCOTCH_ARCH_PATH="$SCOTCH_ROOT"
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/vtk	2020-12-11 21:22:55.463024882 +0100
+@@ -0,0 +1,9 @@
++##Easybuild## settings -*- sh -*-
++
++export VTK_DIR="$EBROOTVTK"
++export MESA_ARCH_PATH="$EBROOTMESA"
++
++# Define paraview-mesa directory as required
++unset ParaView_MESA_DIR
++
++##Easybuild##
+--- /dev/null	2020-12-14 09:05:45.272769166 +0100
++++ OpenFOAM-v2012/etc/easybuild/config.sh/paraview	2020-12-14 10:13:53.583674383 +0100
+@@ -0,0 +1,75 @@
++##Easybuild## settings -*- sh -*-
++#
++# Largely a knockoff of the OpenFOAM etc/config.sh/paraview-system
++# readjusted for easybuild
++#
++# Copyright (C) 2020 OpenCFD Ltd.
++#
++#------------------------------------------------------------------------------
++# Compiler-specific location for ThirdParty installations
++archDir="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER"
++
++# Clean path and library path of previous settings
++eval \
++    "$($WM_PROJECT_DIR/bin/foamCleanPath -sh-env=PATH \
++    $ParaView_DIR $archDir/ParaView- $archDir/qt-)"
++
++eval \
++    "$($WM_PROJECT_DIR/bin/foamCleanPath -sh-env=LD_LIBRARY_PATH \
++    $ParaView_DIR $archDir/ParaView- $archDir/qt-)"
++
++
++#------------------------------------------------------------------------------
++
++##Easybuild## settings
++
++ParaView_VERSION="$EBVERSIONPARAVIEW"
++export ParaView_DIR="$EBROOTPARAVIEW"
++
++#------------------------------------------------------------------------------
++
++unset PV_PLUGIN_PATH
++
++# Set API to correspond to VERSION
++# pv_api is <digits>.<digits> from ParaView_VERSION
++#-
++# Extract API from VERSION
++pv_api=$(echo "$ParaView_VERSION" | \
++    sed -ne 's/^[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p')
++
++pv_plugin_dir="$FOAM_LIBBIN/paraview-$pv_api"
++
++# Set paths if binaries are present
++if [ -r "$ParaView_DIR" ]
++then
++    export PATH="$ParaView_DIR/bin:$PATH"
++
++    # ParaView libraries
++    # - 5.5 and later:   lib/, but could also be lib64/
++    for libDir in lib64 lib
++    do
++        pvLibDir="$libDir/paraview-$pv_api"
++        if [ -d "$ParaView_DIR/$pvLibDir" ]
++        then
++            export LD_LIBRARY_PATH="$ParaView_DIR/$libDir:$LD_LIBRARY_PATH"
++            break
++        fi
++    done
++
++    # OpenFOAM plugin directory must be the first in PV_PLUGIN_PATH
++    # and have paraview-major.minor encoded in its name
++    if [ -d "$pv_plugin_dir" ]
++    then
++        export PV_PLUGIN_PATH="$pv_plugin_dir"
++    fi
++fi
++
++
++#------------------------------------------------------------------------------
++
++unset ParaView_VERSION
++
++unset archDir libDir
++unset pv_api pv_plugin_dir pvLibDir
++
++#------------------------------------------------------------------------------
+--- OpenFOAM-v2312/etc/config.sh/setup.orig    2024-01-11 09:49:24.823571481 +0100
++++ OpenFOAM-v2312/etc/config.sh/setup 2024-01-11 09:51:40.545969774 +0100
+@@ -207,7 +207,9 @@
+ _foamEtc -config  CGAL
+ _foamEtc -config  scotch
+ _foamEtc -config  FFTW
+-
++_foamEtc -config  metis
++_foamEtc -config  kahip
++_foamEtc -config  readline
+ 
+ # Finalize library paths
+ # ~~~~~~~~~~~~~~~~~~~~~~
+

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2412-gompi-2023a.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2412-gompi-2023a.eb
@@ -1,0 +1,58 @@
+name = 'OpenFOAM'
+version = 'v2412'
+
+homepage = 'https://www.openfoam.com/'
+description = """OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'gofb', 'version': '2023a'}
+# Users have found that vectorizion caused OpenFOAM to produce some very incorrect results.
+# Disabling vectorize was confirmed to fix the the known issues.
+# With no test suite, sticking to known working toolchain options until proven otherwise.
+toolchainopts = {'cstd': 'c++14', 'vectorize': False}
+
+sources = [
+    {
+        'filename': SOURCE_TXZ,
+        'git_config': {
+            'url': 'https://develop.openfoam.com/Development',
+            'repo_name': 'openfoam',
+            'tag': 'OpenFOAM-%(version)s',
+            'clone_into': '%(name)s-%(version)s',
+            'recursive': True,
+        }
+    },
+]
+patches = [
+    ('OpenFOAM-v2406-cleanup.patch', 1),
+    ('OpenFOAM-v2212-wmake-OpenMPI.patch', 1),
+]
+checksums = [
+    {SOURCE_TXZ: '80eb3fa525c8346c2828608bc31a80b6827f1f8c92eb1247156b5fc1bb055b8f'},
+    {'OpenFOAM-v2406-cleanup.patch': '3abff48a517fb63719ad57fa32af746bc379a1e80c72d3e5852aa17cd13cf03e'},
+    {'OpenFOAM-v2212-wmake-OpenMPI.patch': '241dc4898c22aab0cbd10c1ea931a07a786508ee03462d45dbc1c202fee3ebe8'},
+]
+
+builddependencies = [
+    ('Bison', '3.8.2'),
+    ('CMake', '3.26.3'),
+    ('flex', '2.6.4'),
+]
+
+dependencies = [
+    ('libreadline', '8.2'),
+    ('ncurses', '6.4'),
+    # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.3'),
+    ('KaHIP', '3.16'),
+    ('CGAL', '5.6'),
+    ('GMP', '6.2.1'),
+    ('MPFR', '4.2.0'),
+    ('ParaView', '5.11.2'),
+    ('gnuplot', '5.4.8'),
+]
+
+moduleclass = 'cae'


### PR DESCRIPTION
Add OpenFOAM v2406 and v2412 files. The v2406 files match what was used to build v2406 on the clusters.

Upstream provided a plugins tarball for the v2406, but not v2412 or earlier releases. These plugins were included in the v2406 easybuild though, so switch source to git checkout for v2412 in order to continue building them.

Used the .txz format as easybuild said it was required for a stable checksum. Rebuilding the source again produced the same checksum, so it does appears to work.

The v2412 requires the [corresponding easybuild-computecanada-config pull request](https://github.com/ComputeCanada/easybuild-computecanada-config/pull/74).