### PR TITLE
Legacy dealii 9.4.1 and PETSc/3.16.6 for StdEnv/2023 (otrs 0277905)

### DIFF
--- a/easybuild/easyconfigs/d/dealii/dealii-9.4.1-foss-20203a.eb
+++ b/easybuild/easyconfigs/d/dealii/dealii-9.4.1-foss-20203a.eb
@@ -1,0 +1,117 @@
+easyblock = 'CMakeMake'
+
+name = 'dealii'
+version = '9.4.1'
+
+homepage = 'http://www.dealii.org/'
+description = """A C++ software library supporting the creation of finite element codes and an open community of users and developers."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+#toolchain = {'name': 'gofb', 'version': '2023a'}
+toolchainopts = {'usempi': True, 'pic': True, 'strict': True}
+
+source_urls = ['https://github.com/dealii/%(namelower)s/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = ['dealii-9.4.1-step70-boost.patch']
+checksums = [
+  'bfe5e4bf069159f93feb0f78529498bfee3da35baf5a9c6852aa59d7ea7c7a48',
+  '6fbcdbe0c41709356f76c2142c0fd81ef56dd19b292f7a90d8d0bc39b15a1536',
+]
+
+# Note: this package is often built with software called candi
+# (due to it's specific dependencies/requirements)
+#    https://aspect-documentation.readthedocs.io/en/latest/user/install/local-installation/using-candi.html
+# This isn't feasible with easybuild, but the candi page has a good test afterwards to ensure
+# it's built correctly:
+#    cp -R $EBROOTDEALII/examples/step-32 .
+#    cd step-32
+#    cmake . && make
+#    mpirun -n 2 ./step-32
+
+separate_build_dir = True
+
+builddependencies = [
+   ('CMake', '3.31.0'),
+   ('Boost', '1.82.0'),
+   ('SymEngine', '0.14.0'),
+   ('nanoflann', '1.7.1'),
+]
+
+dependencies = [
+   ('p4est', '2.8.6'),
+   ('GSL', '2.7'),
+   ('SuiteSparse', '5.13.0'),
+   ('tbb', '2021.10.0'),
+   ('SUNDIALS', '6.6.0'),
+   ('gmsh', '4.13.1'),
+   ('ADOL-C', '2.7.2'),
+   ('arpack-ng', '3.9.1'),
+   ('ASSIMP', '5.2.5'),
+   ('HDF5', '1.14.2', '-mpi'),
+   ('METIS', '5.1.0'),
+   ('muParser', '2.3.4'),
+   ('netCDF-C++4', '4.3.1', '-mpi'),
+   ('PETSc', '3.16.6', '-64bits'),
+   ('SLEPc', '3.16.3', '-64bits'),
+   ('occt', '7.7.1'),
+   ('Trilinos', '13.4.1'),
+   ('METIS', '5.1.0'),
+   ('LLVM', '16.0.6'),
+]
+
+preconfigopts = 'export TRILINOS_DIR=$EBROOTTRILINOS && '
+preconfigopts += 'declare -A ARCH_MAP=( [sse3]=SSE2 [avx]=AVX [avx2]=AVX [avx512]=AVX512 ) && '
+
+configopts = '-DDEAL_II_ALLOW_PLATFORM_INTROSPECTION=OFF '
+configopts += '-DDEAL_II_HAVE_${ARCH_MAP[$RSNT_ARCH]}=ON '
+configopts += '-DDEAL_II_WITH_BOOST=ON -DBOOST_DIR=$EBROOTBOOST '
+configopts += '-DDEAL_II_WITH_P4EST=ON '
+configopts += '-DDEAL_II_WITH_MPI=ON '
+configopts += '-DDEAL_II_WITH_TRILINOS=ON '
+configopts += '-DTBB_DIR=$EBROOTTBB '
+configopts += '-DTrilinos_ENABLE_Sacado=ON '
+configopts += '-DTrilinos_ENABLE_Stratimikos=ON '
+configopts += '-DTrilinos_FIND_COMPONENTS="Pike;PikeImplicit;PikeBlackBox;TrilinosCouplings;Panzer;PanzerMiniEM;PanzerAdaptersSTK;PanzerDiscFE;PanzerDofMgr;PanzerCore;Piro;ROL;Stokhos;Tempus;Rythmos;ShyLU;ShyLU_DD;ShyLU_DDCommon;ShyLU_DDFROSch;ShyLU_DDBDDC;Zoltan2;Zoltan2Sphynx;MueLu;Moertel;NOX;Phalanx;Percept;STK;STKExprEval;STKDoc_tests;STKUnit_tests;STKBalance;STKTools;STKTransfer;STKSearchUtil;STKSearch;STKUnit_test_utils;STKNGP_TEST;STKIO;STKMesh;STKTopology;STKSimd;STKUtil;STKMath;Compadre;Intrepid2;Intrepid;Teko;FEI;Stratimikos;Ifpack2;Anasazi;Komplex;SEACAS;SEACASEx2ex1v2;SEACASTxtexo;SEACASNumbers;SEACASNemspread;SEACASNemslice;SEACASMat2exo;SEACASMapvar-kd;SEACASMapvar;SEACASMapvarlib;SEACASExplore;SEACASGrepos;SEACASGenshell;SEACASGen3D;SEACASGjoin;SEACASFastq;SEACASEx1ex2v2;SEACASExo_format;SEACASExotxt;SEACASExomatlab;SEACASExodiff;SEACASExo2mat;SEACASEpu;SEACASEjoin;SEACASConjoin;SEACASBlot;SEACASAprepro;SEACASAlgebra;SEACASPLT;SEACASSVDI;SEACASSuplibCpp;SEACASSuplibC;SEACASSuplib;SEACASSupes;SEACASAprepro_lib;SEACASChaco;SEACASIoss;SEACASNemesis;SEACASExoIIv2for32;SEACASExodus_for;SEACASExodus;Amesos2;ShyLU_Node;ShyLU_NodeTacho;ShyLU_NodeHTS;Belos;ML;Ifpack;Zoltan2Core;Pamgen;Amesos;Galeri;AztecOO;Pliris;Isorropia;Xpetra;Thyra;ThyraTpetraAdapters;ThyraEpetraExtAdapters;ThyraEpetraAdapters;ThyraCore;Domi;TrilinosSS;Tpetra;TpetraCore;TpetraTSQR;TpetraClassic;EpetraExt;Triutils;Shards;Zoltan;Epetra;MiniTensor;Sacado;RTOp;KokkosKernels;Teuchos;TeuchosKokkosComm;TeuchosKokkosCompat;TeuchosRemainder;TeuchosNumerics;TeuchosComm;TeuchosParameterList;TeuchosParser;TeuchosCore;Kokkos;KokkosAlgorithms;KokkosContainers;KokkosCore;Gtest;TrilinosATDMConfigTests;TrilinosFrameworkTests" '
+configopts += '-DCMAKE_BUILD_TYPE=Release '
+configopts += '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON '
+configopts += '-DBUILD_SHARED_LIBS=ON '
+configopts += '-DCMAKE_C_COMPILER=mpicc '
+configopts += '-DCMAKE_CXX_COMPILER=mpiCC '
+configopts += '-DCMAKE_Fortran_COMPILER=mpif90 '
+configopts += '-DLAPACK_FOUND=true '
+configopts += '-DLAPACK_LIBRARIES="$LIBLAPACK" '
+configopts += '-DSCALAPACK_DIR=$SCALAPACK_LIB_DIR '
+configopts += '-DSCALAPACK_LIBRARIES="$LIBSCALAPACK -lm" '
+configopts += '-DP4EST_DIR=${EBROOTP4EST} '
+configopts += '-DTRILINOS_DIR=${EBROOTTRILINOS} '
+configopts += '-DGSL_LIBRARIES=${EBROOTGSL}/lib/libgsl.a '
+configopts += '-DGSL_INCLUDE_DIRS=${EBROOTGSL}/include '
+configopts += '-DDEAL_II_HAVE_USABLE_FLAGS_RELEASE=ON '
+configopts += '-DGMSH_DIR=$EBROOTGMSH '
+configopts += '-DSUNDIALS_DIR=$EBROOTSUNDIALS '
+configopts += '-DUMFPACK_DIR=$EBROOTSUITESPARSE/UMFPACK '
+configopts += '-DZLIB_INCLUDE_DIR=$EBROOTGENTOO/include '
+configopts += '-DZLIB_LIBRARY=$EBROOTGENTOO/lib64/libz.so '
+configopts += '-DADOLC_DIR=$EBROOTADOLMINC '
+configopts += '-DARPACK_DIR=$EBROOTARPACKMINNG '
+configopts += '-DASSIMP_DIR=$EBROOTASSIMP '
+configopts += '-DHDF5_DIR=$EBROOTHDF5 '
+configopts += '-DMETIS_DIR=$EBROOTMETIS '
+configopts += '-DMETIS_INCLUDE_DIR=$EBROOTMETIS/include '
+configopts += '-DMETIS_LIBRARY=$EBROOTMETIS/lib/libmetis.so '
+configopts += '-DMUPARSER_DIR=$EBROOTMUPARSER '
+configopts += '-DNETCDF_DIR=$EBROOTNETCDFMINCPLUSPLUS '
+configopts += '-DPETSC_DIR=$EBROOTPETSC '
+configopts += '-DSLEPC_DIR=$EBROOTSLEPC '
+configopts += '-DDEAL_II_LINKER_FLAGS=-L$EBROOTGENTOO/lib64/fltk '
+
+# Too parallel is too slow, and may cause build/tests to fail:
+
+maxparallel = 10
+
+sanity_check_paths = {
+    'files': [('lib/libdeal_II.so')],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/d/dealii/dealii-9.4.1-step70-boost.patch
+++ b/easybuild/easyconfigs/d/dealii/dealii-9.4.1-step70-boost.patch
@@ -1,0 +1,31 @@
+From 89b89043c3fc45883e9b11bba6276a23cfd9feb3 Mon Sep 17 00:00:00 2001
+From: David Wells <drwells@email.unc.edu>
+Date: Thu, 8 Dec 2022 10:09:03 -0500
+Subject: [PATCH] step-70: remove a dependency on boost.
+
+---
+ examples/step-70/step-70.cc | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/examples/step-70/step-70.cc b/examples/step-70/step-70.cc
+index 2ce4d97488..879e5c1641 100644
+--- a/examples/step-70/step-70.cc
++++ b/examples/step-70/step-70.cc
+@@ -837,8 +835,12 @@ namespace Step70
+         const auto &manifold_id   = pair.first;
+         const auto &cad_file_name = pair.second;
+ 
+-        const auto extension = boost::algorithm::to_lower_copy(
+-          cad_file_name.substr(cad_file_name.find_last_of('.') + 1));
++        std::string extension =
++          cad_file_name.substr(cad_file_name.find_last_of('.') + 1);
++        std::transform(extension.begin(),
++                       extension.end(),
++                       extension.begin(),
++                       [](const char c) -> char { return std::tolower(c); });
+ 
+         TopoDS_Shape shape;
+         if (extension == "iges" || extension == "igs")
+-- 
+2.50.1
+

--- a/easybuild/easyconfigs/p/PETSc/PETSc-3.16.6-foss-2023a-64bits.eb
+++ b/easybuild/easyconfigs/p/PETSc/PETSc-3.16.6-foss-2023a-64bits.eb
@@ -1,0 +1,118 @@
+# Built with EasyBuild version 5.1.1 on 2025-09-14_15-13-05
+name = 'PETSc'
+version = "3.16.6"
+versionsuffix = '-64bits'
+
+homepage = 'http://www.mcs.anl.gov/petsc'
+description = """PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the
+ scalable (parallel) solution of scientific applications modeled by partial differential equations."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['https://web.cels.anl.gov/projects/%(namelower)s/download/release-snapshots/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'bfc836b52f57686b583c16ab7fae0c318a7b28141ca01656ad673c8ca23037fa',
+]
+
+dependencies = [
+    ('HDF5', '1.14.2', '-mpi'),
+]
+
+# For the extension
+builddependencies = [
+    ('SciPy-Stack', '2025a'),
+    ('mpi4py', '4.0.3'),
+]
+
+multi_deps = {'Python': ['3.10']}
+multi_deps_extensions_only = True
+
+configopts = " ".join([
+    '--with-hdf5=1',
+    '--with-hdf5-dir=$EBROOTHDF5',
+    '--with-cxx-dialect=C++14',
+    '--with-memalign=64',
+    '--with-python=no',
+    '--with-mpi4py=no',
+    '--with-64-bit-indices=1',
+])
+# Fix usage of MAKEFLAGS (can't add to start as may be missing leading dash and can't add to end as contains --)
+prebuildopts = 'sed -i -e \'s/MAKEFLAGS="\\([^"]*\\) $(MAKEFLAGS)" \\+\\([^ ]*\\)/\\2 \\1/\' lib/petsc/conf/* && '
+
+
+download_deps = [
+    'triangle',
+    'hpddm',
+    'strumpack',
+]
+
+postinstallcmds = [
+    'ln -sf %(installdir)s/lib/%(namelower)s/bin %(installdir)s/bin',
+    'ln -sf %(installdir)s/lib/%(namelower)s/conf %(installdir)s/conf',
+]
+
+keepsymlinks = True
+
+shared_libs = 1
+
+download_deps_static = [
+    'f2cblaslapack',
+    'mumps',
+    'ptscotch',
+    #'superlu',
+    'superlu_dist',
+    'parmetis',
+    'metis',
+    #'ml',
+    'SuiteSparse',
+    'hypre',
+    'prometheus',
+    'spooles',
+    #'chaco',
+    'slepc',
+    #'spai',
+    #'party',
+]
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    # disable "pip check" which would fail with several:
+    # > $PACKAGE requires (numpy|mpi4py|msgpack), which is not installed 
+    'sanity_pip_check': False,
+}
+exts_list = [
+    ('petsc4py', version, {
+        'buildopts': '#',
+        'check_ldshared': False,
+        'modulename': 'petsc4py',
+        'preconfigopts': '#',
+        #'preconfigopts': 'find -name \'*.c\' -print0 | xargs -0 sed -i -e \'/# *include.*longintrepr/d\'',
+        'use_pip': True,
+        'runtest': False,
+        'source_urls': ['https://pypi.python.org/packages/source/%(nameletter)s/%(name)s'],
+        'checksums' : ['a9b4ed19ca2e62b38da51ac3a70539d9581a1354cc4464c93963d7e95bd8ef66'],
+    }),
+]
+
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+sanity_check_paths = {
+    'files': [
+        'lib/libpetsc.so',
+    ],
+    'dirs': [
+        'bin',
+        'conf',
+        'include',
+        'lib',
+        'share',
+        'lib/python%(pyshortver)s/site-packages'
+    ]
+}
+
+moduleclass = 'numlib'
+modluafooter = """
+family("%(namelower)s")
+"""

--- a/easybuild/easyconfigs/s/SLEPc/SLEPc-3.16.3-foss-2023a.eb
+++ b/easybuild/easyconfigs/s/SLEPc/SLEPc-3.16.3-foss-2023a.eb
@@ -1,0 +1,52 @@
+name = 'SLEPc'
+version = '3.16.3'
+versionsuffix = '-64bits'
+
+homepage = 'https://slepc.upv.es/'
+description = """SLEPc (Scalable Library for Eigenvalue Problem Computations) is a software library for the solution
+ of large scale sparse eigenvalue problems on parallel computers. It is an extension of PETSc and can be used for
+ either standard or generalized eigenproblems, with real or complex arithmetic. It can also be used for computing a
+ partial SVD of a large, sparse, rectangular matrix, and to solve quadratic eigenvalue problems."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://slepc.upv.es/download/distrib']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b92bd170632a3de4d779f3f0697e7cb9b663e2c34606c9e97d899d7c1868014e']
+
+# sources = ['%(namelower)s-%(version)s.tar.gz']
+dependencies = [('PETSc', '3.16.6', '-64bits')]
+# For the extension
+builddependencies = [
+    ('SciPy-Stack', '2025a'),
+    ('mpi4py', '4.0.3'),
+]
+
+multi_deps = {'Python': ['3.10']}
+multi_deps_extensions_only = True
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    # disable "pip check" which would fail with several:
+    # > $PACKAGE requires (numpy|mpi4py|msgpack), which is not installed 
+    'sanity_pip_check': False,
+}
+exts_list = [
+    ('slepc4py', '3.16.3', {
+        'modulename': 'slepc4py',
+        'source_urls': [PYPI_SOURCE],
+        'checksums' : ['d97652efe60163d30c24eb1ef1b1ba98bb8239fd7452bdf8207c2505da48d77e'],
+        'preconfigopts': '#',
+	'check_ldshared': False,
+	'buildopts': '#',
+        'runtest': False,
+    }),
+]
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+petsc_arch = 'installed-arch-linux2-c-opt'
+
+#modextrapaths = {'EBPYTHONPREFIXES': [''],}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/t/Trilinos/Trilinos-13.4.1-gofb-2023a.eb
+++ b/easybuild/easyconfigs/t/Trilinos/Trilinos-13.4.1-gofb-2023a.eb
@@ -1,0 +1,60 @@
+# Built with EasyBuild version 5.1.1 on 2025-08-23_23-51-35
+name = 'Trilinos'
+version = "13.4.1"
+
+homepage = 'https://trilinos.org'
+description = """The Trilinos Project is an effort to develop algorithms and enabling technologies
+ within an object-oriented software framework for the solution of large-scale, complex multi-physics
+ engineering and scientific problems. A unique design feature of Trilinos is its focus on packages."""
+
+toolchain = {'name': 'gofb', 'version': '2023a'}
+toolchainopts = {'usempi': True, 'pic': True, 'strict': True}
+
+source_urls = [
+    'https://github.com/trilinos/Trilinos/archive'
+]
+sources = ['%%(namelower)s-release-%s.tar.gz' % '-'.join(version.split('.'))]
+patches = ['Trilinos-13.4.1.patch']
+checksums = [
+    '5465cbff3de7ef4ac7d40eeff9d99342c00d9d20eee0a5f64f0a523093f5f1b3',
+    'affdfb65504562d43bcb36d41dfc7641e6b72f11d643cee6bec3fa1e13aa41cb',
+]
+
+multi_deps_load_default = False
+multi_deps = {"Python": ["3.11"]}
+
+builddependencies = [
+    ('Boost', '1.82.0'),
+    ('netCDF', '4.9.2', '-mpi'),
+    ('MATIO', '1.5.26'),
+    ('SWIG', '4.1.1'),
+    ('CMake', '3.27.7'), 
+]
+
+preconfigopts  = "unset EBPYTHONPREFIXES && "
+preconfigopts += "pyver=$(python -c 'import sys; print(\"python%s.%s\"%sys.version_info[:2])') && "
+preconfigopts += "pip install numpy --prefix=%(installdir)s && "
+preconfigopts += "export PYTHONPATH=$PYTHONPATH:%(installdir)s/lib/$pyver/site-packages && "
+preconfigopts += "export CPATH=$CPATH:%(installdir)s/lib/$pyver/site-packages/numpy/core/include && "
+
+configopts  = '-DNetCDF_NEEDS_HDF5=ON -DShyLU_NodeTacho_ENABLE_EXAMPLES=OFF -DShyLU_Node_ENABLE_EXAMPLES=OFF '
+configopts += '-DXpetra_ENABLE_EXAMPLES=OFF -DXpetra_ENABLE_TESTS=OFF -DIfpack2_ENABLE_TESTS=OFF '
+configopts += '-DShyLU_DDFROSch_ENABLE_TESTS=OFF -DShyLU_DD_ENABLE_TESTS=OFF '
+configopts += '-DTrilinosCouplings_ENABLE_EXAMPLES=OFF -DMPI_BASE_DIR=$EBROOTOPENMPI'
+
+openmp = False
+
+build_shared_libs = True
+
+preinstallopts = preconfigopts
+
+postinstallcmds = [
+   "sed -i 's/PyTrilinos;//' %(installdir)s/lib/cmake/Trilinos/TrilinosConfig.cmake",
+]
+
+# too parallel is too slow because of memory requirements (results in swapping), and may cause build/tests to fail
+# building with 20 cores seems to require about 100GB of memory (peak usage)
+
+maxparallel = 10
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/t/Trilinos/Trilinos-13.4.1.patch
+++ b/easybuild/easyconfigs/t/Trilinos/Trilinos-13.4.1.patch
@@ -1,0 +1,34 @@
+--- Trilinos-trilinos-release-13-4-1/packages/seacas/libraries/exodus/src/ex_utils.c~	2022-11-10 17:02:37.000000000 -0500
++++ Trilinos-trilinos-release-13-4-1/packages/seacas/libraries/exodus/src/ex_utils.c	2025-08-23 11:40:44.408198839 -0400
+@@ -1742,7 +1742,7 @@
+         */
+ 
+         /* const int NC_SZIP_EC = 4; */ /* Selects entropy coding method for szip. */
+-        const int NC_SZIP_NN = 32;      /* Selects nearest neighbor coding method for szip. */
++        /* const int NC_SZIP_NN = 32; */ /* Selects nearest neighbor coding method for szip. */
+         /* Even and between 4 and 32; typical values are 8, 10, 16, 32 */
+         const int SZIP_PIXELS_PER_BLOCK =
+             file->compression_level == 0 ? 32 : file->compression_level;
+--- Trilinos-trilinos-release-13-4-1/packages/seacas/applications/blot/mscomd.f~	2022-11-10 17:02:37.000000000 -0500
++++ Trilinos-trilinos-release-13-4-1/packages/seacas/applications/blot/mscomd.f	2025-08-23 12:56:51.195840808 -0400
+@@ -482,8 +482,8 @@
+             CALL INIINT (3, 1, LTYP)
+             CALL SETMSH (2, 'UNDEFORM', 'NONE', MSHSEL, LTYP,
+      &         0, IDUM, 0, IDUM, 'WIREFRAM', ' ', ISSNPS, ISSESS)
+-            CALL SCOLOR (.TRUE., CDUM, IDUM, IDUM, RDUM, IDUM,
+-     *        CDUM, SHDCOL, ISHDCL, IDELB)
++            CALL SCOLOR (.TRUE., INLINE, IFLD, INTYP,
++     &         RFIELD, IFIELD, CFIELD, SHDCOL, ISHDCL, IDELB)
+ 
+ C         --Set display options
+ 
+--- Trilinos-trilinos-release-13-4-1/packages/PyTrilinos/src/numpy_include.hpp~	2022-11-10 17:02:37.000000000 -0500
++++ Trilinos-trilinos-release-13-4-1/packages/PyTrilinos/src/numpy_include.hpp	2025-08-23 21:45:37.201104575 -0400
+@@ -60,6 +60,7 @@
+ // import_array().
+ 
+ #include <Python.h>
++#define NPY_API_SYMBOL_ATTRIBUTE
+ #define PY_ARRAY_UNIQUE_SYMBOL PyTrilinos_NumPy
+ #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+ #include <numpy/arrayobject.h>


### PR DESCRIPTION
This adds legacy dealii (9.4.1), PETSc (3.16.6), and, as a required dependency, Trilinos (13.4.1) to StdEnv/2023 for the new clusters. These were requested as dependencies for OpenIFEM (otrs 0277905).

Trillinos SCOLOR patch works as arguments are ignored if init argument is .TRUE. (existing types were incompatible). Dealli patch based on later upstream commits.